### PR TITLE
Update GitHub client version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github/v29 v29.0.3 // indirect
 	github.com/google/go-github/v32 v32.1.0
+	github.com/google/go-github/v39 v39.0.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/ossf/scorecard v1.2.1-0.20210722153731-89c8e2af3131
 	github.com/rs/zerolog v1.22.0
 	gocloud.dev v0.23.0
-	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	google.golang.org/genproto v0.0.0-20210719143636-1d5a45f8e492 // indirect

--- a/go.sum
+++ b/go.sum
@@ -626,6 +626,8 @@ github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
+github.com/google/go-github/v39 v39.0.0 h1:pygGA5ySwxEez1N39GnDauD0PaWWuGgayudyZAc941s=
+github.com/google/go-github/v39 v39.0.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
@@ -1426,6 +1428,8 @@ golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ossf/allstar/pkg/config/operator"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 )
 
 var getContents func(context.Context, string, string, string,

--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ossf/allstar/pkg/policies"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/rs/zerolog/log"
 )
 
@@ -81,13 +81,13 @@ func EnforceAll(ctx context.Context, ghc *ghclients.GHClients) error {
 		}
 		err = nil
 		for {
-			var rs []*github.Repository
+			var rs *github.ListRepositories
 			var resp *github.Response
 			rs, resp, err = ic.Apps.ListRepos(ctx, opt)
 			if err != nil {
 				break
 			}
-			repos = append(repos, rs...)
+			repos = append(repos, rs.Repositories...)
 			if resp.NextPage == 0 {
 				break
 			}

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/policydef"
 )
 

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/gregjones/httpcache"
 	"github.com/ossf/allstar/pkg/config/operator"
 	"gocloud.dev/runtimevar"

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/config/operator"
 )
 

--- a/pkg/issue/issue_test.go
+++ b/pkg/issue/issue_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/config/operator"
 )
 

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -25,7 +25,8 @@ import (
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v32/github"
+	gh32 "github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/scorecard/checker"
 	"github.com/ossf/scorecard/checks"
 	"github.com/ossf/scorecard/clients/githubrepo"
@@ -114,7 +115,8 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
 
-	repoClient := githubrepo.CreateGithubRepoClient(ctx, c)
+	oldClient := gh32.NewClient(c.Client())
+	repoClient := githubrepo.CreateGithubRepoClient(ctx, oldClient)
 	if err := repoClient.InitRepo(owner, repo); err != nil {
 		return nil, err
 	}
@@ -122,7 +124,7 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 	l := logger{}
 	cr := &checker.CheckRequest{
 		Ctx:         ctx,
-		Client:      c,
+		Client:      oldClient,
 		RepoClient:  repoClient,
 		HTTPClient:  nil,
 		Owner:       owner,

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 )

--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 )
@@ -87,13 +87,13 @@ func TestCheck(t *testing.T) {
 			Users: []*github.User{
 				&github.User{
 					Login: &alice,
-					Permissions: &map[string]bool{
+					Permissions: map[string]bool{
 						"push": true,
 					},
 				},
 				&github.User{
 					Login: &bob,
-					Permissions: &map[string]bool{
+					Permissions: map[string]bool{
 						"push": true,
 					},
 				},
@@ -120,13 +120,13 @@ func TestCheck(t *testing.T) {
 			Users: []*github.User{
 				&github.User{
 					Login: &alice,
-					Permissions: &map[string]bool{
+					Permissions: map[string]bool{
 						"push": true,
 					},
 				},
 				&github.User{
 					Login: &bob,
-					Permissions: &map[string]bool{
+					Permissions: map[string]bool{
 						"push":  true,
 						"admin": true,
 					},

--- a/pkg/policies/security/security.go
+++ b/pkg/policies/security/security.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/policies/security/security_test.go
+++ b/pkg/policies/security/security_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 )

--- a/pkg/policydef/policydef.go
+++ b/pkg/policydef/policydef.go
@@ -26,7 +26,7 @@ package policydef
 import (
 	"context"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v39/github"
 )
 
 // Result is returned from a policy check.


### PR DESCRIPTION
Before we were in lock-step with Scorecards in order to share clients. Now,
go-github has added a method to get the internal http client, therefore we can
create new GitHub clients on the fly to convert major versions. See binary.go
for conversion.