### PR TITLE
Log cache size and repo count every enforce loop.

### DIFF
--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-github/v39/github"
 	"github.com/gregjones/httpcache"
 	"github.com/ossf/allstar/pkg/config/operator"
-	"github.com/rs/zerolog/log"
 	"gocloud.dev/runtimevar"
 	_ "gocloud.dev/runtimevar/gcpsecretmanager"
 )
@@ -91,14 +90,7 @@ func (g *GHClients) Get(i int64) (*github.Client, error) {
 }
 
 func (g *GHClients) LogCacheSize() {
-	var total int
-	for _, b := range g.cache.Items {
-		total = total + len(b)
-	}
-	log.Info().
-		Str("area", "bot").
-		Int("size", total).
-		Msg("Total cache size.")
+	g.cache.LogCacheSize()
 }
 
 func getKeyReal(ctx context.Context) ([]byte, error) {

--- a/pkg/ghclients/memorycache.go
+++ b/pkg/ghclients/memorycache.go
@@ -1,0 +1,61 @@
+// Copyright © 2012 Greg Jones (greg.jones@gmail.com)
+// Copyright 2021 Allstar Authors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the “Software”), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+package ghclients
+
+import "sync"
+
+// memoryCache is an implemtation of httpcache.Cache that stores responses in
+// an in-memory map.  It is a copy of httpcache.MemoryCache but exposes Items
+// to allow for calculating and logging the cache size.
+type memoryCache struct {
+	mu    sync.RWMutex
+	Items map[string][]byte
+}
+
+// Get returns the []byte representation of the response and true if present,
+// false if not
+func (c *memoryCache) Get(key string) (resp []byte, ok bool) {
+	c.mu.RLock()
+	resp, ok = c.Items[key]
+	c.mu.RUnlock()
+	return resp, ok
+}
+
+// Set saves response resp to the cache with key
+func (c *memoryCache) Set(key string, resp []byte) {
+	c.mu.Lock()
+	c.Items[key] = resp
+	c.mu.Unlock()
+}
+
+// Delete removes key from the cache
+func (c *memoryCache) Delete(key string) {
+	c.mu.Lock()
+	delete(c.Items, key)
+	c.mu.Unlock()
+}
+
+// newMemoryCache returns a new memoryCache that will store items in an
+// in-memory map
+func newMemoryCache() *memoryCache {
+	c := &memoryCache{Items: map[string][]byte{}}
+	return c
+}


### PR DESCRIPTION
This also uses a single cache instead of separate cache per installation. I
believe the query params for listing the repos of an installation are different
so these won't collide.