### PR TITLE
Issues repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ Two settings are available to configure the issue action:
   will override the default `allstar` label used by Allstar to identify its
   issues.
 
-- `issueRepo` is available at the orgainaztion level. Setting it will force all
-  issues created in the organization to be created in the repo specfied.
+- `issueRepo` is available at the organization level. Setting it will force all
+  issues created in the organization to be created in the repository specified.
 
 ## **Policies**
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ future.
 - `email`: Allstar would send an email to the repository administrator(s).
 - `rpc`: Allstar would send an rpc to some organization-specific system.
 
+### **Action configuration**
+
+Two settings are available to configure the issue action:
+
+- `issueLabel` is available at the organization and repository level. Setting it
+  will override the default `allstar` label used by Allstar to identify its
+  issues.
+
+- `issueRepo` is available at the orgainaztion level. Setting it will force all
+  issues created in the organization to be created in the repo specfied.
+
 ## **Policies**
 
 Similar to the Allstar app enable configuration, all policies are enabled and

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,20 @@ type OrgConfig struct {
 	// created by the bot. The defeault is specified by the operator of Allstar,
 	// currently: "allstar"
 	IssueLabel string `yaml:"issueLabel"`
+
+	// IssueRepo is the name of a repository in the organization to create issues
+	// in. If left unset, by default Allstar will create issues in the repository
+	// that is out of compliance. Setting the IssueRepo will instruct Allstar to
+	// only create issues in the specified repository for non-compliance found in
+	// any repository in the organization.
+	//
+	// This can be useful for previewing the issues that Allstar would create in
+	// all repositories. Also, it can be used to centrally audit non-compliance
+	// issues.
+	//
+	// Note: When changing this setting, Allstar does not clean up previously
+	// created issues from a previous setting.
+	IssueRepo string `yaml:"issueRepo"`
 }
 
 // OrgOptConfig is used in Allstar and policy-secific org-level config to

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -102,6 +102,16 @@ issueLabel: testlabel
 			Got: &OrgConfig{},
 		},
 		{
+			Name: "IssueRepo",
+			Input: `
+issueRepo: testrepository
+`,
+			Expect: &OrgConfig{
+				IssueRepo: "testrepository",
+			},
+			Got: &OrgConfig{},
+		},
+		{
 			Name: "OptOutRepo",
 			Input: `
 optConfig:


### PR DESCRIPTION
Add the `issueRepo` setting at the org level to direct all issue creation to a single repo for the whole org.

See https://github.com/jeffmendoza/.jtp/issues for an example.

Fixes #58 #59
