### PR TITLE
Only run Scorecard Binary Artifacts if enabled to save time.

### DIFF
--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -115,6 +115,17 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
+	if !enabled {
+		// Don't run this policy unless enabled, as it is expensive. This is only
+		// checking enablement of policy, but not Allstar overall, this is ok for
+		// now.
+		return &policydef.Result{
+			Enabled:    enabled,
+			Pass:       true,
+			NotifyText: "Disabled",
+			Details:    details{},
+		}, nil
+	}
 
 	oldClient := gh32.NewClient(c.Client())
 	repoClient := githubrepo.CreateGithubRepoClient(ctx, oldClient)


### PR DESCRIPTION
I'd like to speed up Allstar before moving to the webhook model. Currently the slowest part is downloading the tarball for every repo.