### PR TITLE
Add fix support to Branch Protection policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,7 @@ optConfig:
 action: issue
 ```
 
-The `fix` action is not implemented in any policy yet, but will be implemented
-in those policies where it is applicable soon.
+The details of how the `fix` action works for each policy is detailed below. If omitted below, the `fix` action is not applicable.
 
 ### Branch Protection
 
@@ -205,6 +204,8 @@ are setup correctly according to the specified configuration. The issue text
 will describe which setting is incorrect. See [GitHub's
 documentation](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
 for correcting settings.
+
+The `fix` action will change the branch protection settings to be in compliance with the specified policy configuration.
 
 ### Binary Artifacts
 

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -290,7 +290,7 @@ func fix(ctx context.Context, rep repositories, c *github.Client,
 	if err != nil {
 		return err
 	}
-	if enabled == false {
+	if !enabled {
 		return nil
 	}
 	mc := mergeConfig(oc, rc, repo)
@@ -374,7 +374,7 @@ func fix(ctx context.Context, rep repositories, c *github.Client,
 			}
 			pr.Restrictions = rr
 		}
-		if *pr.AllowForcePushes == true && mc.BlockForce {
+		if *pr.AllowForcePushes && mc.BlockForce {
 			f := false
 			pr.AllowForcePushes = &f
 			update = true


### PR DESCRIPTION
This will add support to the service, but we will need to update the permissions required by the GitHub App to include "admin:write" https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-administration
This will send a notification to all installation owners. The perm is optional, but `fix` won't work without it.