### PR TITLE
Add setting to Outside Collaborator policy to require an administrator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Collaborators](https://docs.github.com/en/organizations/managing-access-to-your-
 have either administrator(default) or push(optional) access to the
 repository. Only organization members should have this access, as otherwise
 untrusted members can change admin level settings and commit malicious code.
+Also, by default, all repositories must have an organization user or group assigned as an Administrator.
 
 ### SECURITY.md
 


### PR DESCRIPTION
By default, the OC policy will not allow repos without an assigned organization administrator user or group. Setting `ownerlessAllowed` to true in config will disable this.