### PR TITLE
Temporarily disable Ownerless check due to GitHub API bug.

### DIFF
--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -222,10 +222,11 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Details: d,
 	}
 
-	if d.OwnerCount == 0 && !mc.OwnerlessAllowed {
-		rv.Pass = false
-		rv.NotifyText = rv.NotifyText + ownerlessText
-	}
+	// FIXME Ownerless not working due to bug in List Teams GitHub API
+	// if d.OwnerCount == 0 && !mc.OwnerlessAllowed {
+	// 	rv.Pass = false
+	// 	rv.NotifyText = rv.NotifyText + ownerlessText
+	// }
 
 	exp := false
 	if d.OutsidePushCount > 0 && !mc.PushAllowed {

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -199,45 +199,45 @@ func TestCheck(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name: "Ownerless blocked",
-			Org: OrgConfig{
-				OptConfig: config.OrgOptConfig{
-					OptOutStrategy: true,
-				},
-				PushAllowed:      true,
-				AdminAllowed:     true,
-				OwnerlessAllowed: false,
-			},
-			Repo: RepoConfig{},
-			Users: []*github.User{
-				&github.User{
-					Login: &alice,
-					Permissions: map[string]bool{
-						"push": true,
-					},
-				},
-				&github.User{
-					Login: &bob,
-					Permissions: map[string]bool{
-						"push":  true,
-						"admin": true,
-					},
-				},
-			},
-			cofigEnabled: true,
-			Exp: policydef.Result{
-				Enabled:    true,
-				Pass:       false,
-				NotifyText: "Did not find any owners of this repository\nThis policy requires all repositories to have an organization member or team assigned as an administrator",
-				Details: details{
-					OutsidePushCount:  2,
-					OutsidePushers:    []string{"alice", "bob"},
-					OutsideAdminCount: 1,
-					OutsideAdmins:     []string{"bob"},
-				},
-			},
-		},
+		// {
+		// 	Name: "Ownerless blocked",
+		// 	Org: OrgConfig{
+		// 		OptConfig: config.OrgOptConfig{
+		// 			OptOutStrategy: true,
+		// 		},
+		// 		PushAllowed:      true,
+		// 		AdminAllowed:     true,
+		// 		OwnerlessAllowed: false,
+		// 	},
+		// 	Repo: RepoConfig{},
+		// 	Users: []*github.User{
+		// 		&github.User{
+		// 			Login: &alice,
+		// 			Permissions: map[string]bool{
+		// 				"push": true,
+		// 			},
+		// 		},
+		// 		&github.User{
+		// 			Login: &bob,
+		// 			Permissions: map[string]bool{
+		// 				"push":  true,
+		// 				"admin": true,
+		// 			},
+		// 		},
+		// 	},
+		// 	cofigEnabled: true,
+		// 	Exp: policydef.Result{
+		// 		Enabled:    true,
+		// 		Pass:       false,
+		// 		NotifyText: "Did not find any owners of this repository\nThis policy requires all repositories to have an organization member or team assigned as an administrator",
+		// 		Details: details{
+		// 			OutsidePushCount:  2,
+		// 			OutsidePushers:    []string{"alice", "bob"},
+		// 			OutsideAdminCount: 1,
+		// 			OutsideAdmins:     []string{"bob"},
+		// 		},
+		// 	},
+		// },
 		{
 			Name: "Ownerless OK",
 			Org: OrgConfig{


### PR DESCRIPTION
ListTeams is not working unless Allstar is installed on all repos of the
org. Seems to be a GitHub bug. Not sure if this will be fixed and this code can
be re enabled, or if it will need to be refactored to use a different API.