### PR TITLE
Setup staging environment for Allstar.

### DIFF
--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -1,0 +1,11 @@
+runtime: custom
+env: flex
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 2
+  memory_gb: 12
+  disk_size_gb: 100
+env_variables:
+  APP_ID: 119816
+  KEY_SECRET: "gcpsecretmanager://projects/allstar-ossf/secrets/allstar-private-key?decoder=bytes"

--- a/app-staging.yaml
+++ b/app-staging.yaml
@@ -1,0 +1,12 @@
+runtime: custom
+env: flex
+service: staging
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 2
+  memory_gb: 12
+  disk_size_gb: 100
+env_variables:
+  APP_ID: 166485
+  KEY_SECRET: "gcpsecretmanager://projects/allstar-ossf/secrets/allstar-staging-private-key?decoder=bytes"

--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,0 @@
-runtime: custom
-env: flex
-manual_scaling:
-  instances: 1
-resources:
-  cpu: 2
-  memory_gb: 12
-  disk_size_gb: 100

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,8 @@ steps:
   args: ['-c', 'KO_DOCKER_REPO="gcr.io/allstar-ossf" /go/bin/ko publish ./cmd/allstar > container']
 - name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: bash
-  args: ['-c', 'gcloud app deploy --project=allstar-ossf --image-url $(cat container)']
+  args: ['-c', 'gcloud app deploy --appyaml=app-staging.yaml --project=allstar-ossf --image-url $(cat container)']
+timeout: 900s
 options:
   volumes:
   - name: go-modules

--- a/pkg/config/operator/operator.go
+++ b/pkg/config/operator/operator.go
@@ -15,17 +15,25 @@
 // Package operator contains config to be set by the GitHub App operator
 package operator
 
-import "time"
+import (
+	"os"
+	"strconv"
+	"time"
+)
 
 // AppID should be set to the application ID of the created GitHub App. See:
 // https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
-const AppID = 119816
+const setAppID = 119816
+
+var AppID int64
 
 // KeySecret should be set to the name of a secret containing a private key for
 // the App. See:
 // https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-private-key
 // The secret is retrieved with gocloud.dev/runtimevar.
-const KeySecret = "gcpsecretmanager://projects/allstar-ossf/secrets/allstar-private-key?decoder=bytes"
+const setKeySecret = "gcpsecretmanager://projects/allstar-ossf/secrets/allstar-private-key?decoder=bytes"
+
+var KeySecret string
 
 // OrgConfigRepo is the name of the expected org-level repo to contain config.
 const OrgConfigRepo = ".allstar"
@@ -53,3 +61,27 @@ Issue created by Allstar. See https://github.com/ossf/allstar/ for more informat
 // NoticePingDuration is the duration to wait between pinging notice actions,
 // such as updating a GitHub issue.
 const NoticePingDuration = (24 * time.Hour)
+
+var osGetenv func(string) string
+
+func init() {
+	osGetenv = os.Getenv
+	setVars()
+}
+
+func setVars() {
+	appIDs := osGetenv("APP_ID")
+	appID, err := strconv.ParseInt(appIDs, 10, 64)
+	if err == nil {
+		AppID = appID
+	} else {
+		AppID = setAppID
+	}
+
+	keySecret := osGetenv("KEY_SECRET")
+	if keySecret != "" {
+		KeySecret = keySecret
+	} else {
+		KeySecret = setKeySecret
+	}
+}

--- a/pkg/config/operator/operator_test.go
+++ b/pkg/config/operator/operator_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Allstar Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package operator contains config to be set by the GitHub App operator
+package operator
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSetVars(t *testing.T) {
+	tests := []struct {
+		Name         string
+		AppID        string
+		KeySecret    string
+		ExpAppID     int64
+		ExpKeySecret string
+	}{
+		{
+			Name:         "NoVars",
+			AppID:        "",
+			KeySecret:    "",
+			ExpAppID:     setAppID,
+			ExpKeySecret: setKeySecret,
+		},
+		{
+			Name:         "SetVars",
+			AppID:        "123",
+			KeySecret:    "asdf",
+			ExpAppID:     123,
+			ExpKeySecret: "asdf",
+		},
+		{
+			Name:         "BadInt",
+			AppID:        "notint",
+			KeySecret:    "",
+			ExpAppID:     setAppID,
+			ExpKeySecret: setKeySecret,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			osGetenv = func(in string) string {
+				if in == "APP_ID" {
+					return test.AppID
+				}
+				if in == "KEY_SECRET" {
+					return test.KeySecret
+				}
+				return ""
+			}
+			setVars()
+			if diff := cmp.Diff(test.ExpAppID, AppID); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.ExpKeySecret, KeySecret); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Using cloudbuild.yaml, Allstar will deploy to staging first with
app-staging.yaml The appengine yamls will set enviornment variables to
differientate between staging and prod. The pkg/config/operator package will
pull in these settings from the environment variables. There will be a seperate
yaml, similar to cloudbuild.yaml for deploying to prod using
app-prod.yaml. This will be entered directly into Cloud Build, and triggered
manually.