### PR TITLE
Add Organization level custom footer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,14 @@ type OrgConfig struct {
 	// Note: When changing this setting, Allstar does not clean up previously
 	// created issues from a previous setting.
 	IssueRepo string `yaml:"issueRepo"`
+
+	// IssueFooter is a custom message to add to the end of all Allstar created
+	// issues in the GitHub organization. It does not supercede the bot-level
+	// footer (found in pkg/config/operator) but is added in addition to that
+	// one. This setting is useful to direct users to the organization-level
+	// config repository or documentation describing your Allstar settings and
+	// policies.
+	IssueFooter string `yaml:"issueFooter"`
 }
 
 // OrgOptConfig is used in Allstar and policy-secific org-level config to

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -112,6 +112,16 @@ issueRepo: testrepository
 			Got: &OrgConfig{},
 		},
 		{
+			Name: "IssueFooter",
+			Input: `
+issueFooter: testfooter
+`,
+			Expect: &OrgConfig{
+				IssueFooter: "testfooter",
+			},
+			Got: &OrgConfig{},
+		},
+		{
 			Name: "OptOutRepo",
 			Input: `
 optConfig:

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -91,8 +91,15 @@ func ensure(ctx context.Context, c *github.Client, issues issues, owner, repo, p
 		return err
 	}
 	if issue == nil {
+		oc, _ := configGetAppConfigs(ctx, c, owner, repo)
+		var footer string
+		if oc.IssueFooter == "" {
+			footer = operator.GitHubIssueFooter
+		} else {
+			footer = fmt.Sprintf("%v\n%v", oc.IssueFooter, operator.GitHubIssueFooter)
+		}
 		body := fmt.Sprintf("Allstar has detected that this repository’s %v security policy is out of compliance. Status:\n%v\n\n%v",
-			policy, text, operator.GitHubIssueFooter)
+			policy, text, footer)
 		new := &github.IssueRequest{
 			Title:  &title,
 			Body:   &body,


### PR DESCRIPTION
Add to org level config a setting to allow specifying a custom footer text to
be included in all created issues in that org. This is useful to direct users
to org level settings, contacts, documentation, etc.