### PR TITLE
Update issue text.

### DIFF
--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -96,10 +96,12 @@ func ensure(ctx context.Context, c *github.Client, issues issues, owner, repo, p
 		if oc.IssueFooter == "" {
 			footer = operator.GitHubIssueFooter
 		} else {
-			footer = fmt.Sprintf("%v\n%v", oc.IssueFooter, operator.GitHubIssueFooter)
+			footer = fmt.Sprintf("%v\n\n%v", oc.IssueFooter, operator.GitHubIssueFooter)
 		}
-		body := fmt.Sprintf("Allstar has detected that this repository’s %v security policy is out of compliance. Status:\n%v\n\n%v",
-			policy, text, footer)
+		body := fmt.Sprintf("_This issue was automatically created by [Allstar](https://github.com/ossf/allstar/)._\n\n"+
+			"**Security Policy Violation**\n"+
+			"%v\n\n---\n\n%v",
+			text, footer)
 		new := &github.IssueRequest{
 			Title:  &title,
 			Body:   &body,

--- a/pkg/issue/issue_test.go
+++ b/pkg/issue/issue_test.go
@@ -63,7 +63,7 @@ func TestEnsure(t *testing.T) {
 	issueTitle := "Security Policy violation thispolicy"
 	closed := "closed"
 	open := "open"
-	body := "Allstar has detected that this repository’s thispolicy security policy is out of compliance. Status:\nStatus text\n\nThis issue will auto resolve when the policy is in compliance.\n\nIssue created by Allstar. See https://github.com/ossf/allstar/ for more information. For questions specific to the repository, please contact the owner or maintainer."
+	body := "_This issue was automatically created by [Allstar](https://github.com/ossf/allstar/)._\n\n**Security Policy Violation**\nStatus text\n\n---\n\nThis issue will auto resolve when the policy is in compliance.\n\nIssue created by Allstar. See https://github.com/ossf/allstar/ for more information. For questions specific to the repository, please contact the owner or maintainer."
 	configGetAppConfigs = func(context.Context, *github.Client, string, string) (*config.OrgConfig, *config.RepoConfig) {
 		return &config.OrgConfig{}, &config.RepoConfig{}
 	}
@@ -101,7 +101,7 @@ func TestEnsure(t *testing.T) {
 		configGetAppConfigs = func(context.Context, *github.Client, string, string) (*config.OrgConfig, *config.RepoConfig) {
 			return &config.OrgConfig{IssueFooter: "CustomFooter"}, &config.RepoConfig{}
 		}
-		bodyWithFooter := "Allstar has detected that this repository’s thispolicy security policy is out of compliance. Status:\nStatus text\n\nCustomFooter\nThis issue will auto resolve when the policy is in compliance.\n\nIssue created by Allstar. See https://github.com/ossf/allstar/ for more information. For questions specific to the repository, please contact the owner or maintainer."
+		bodyWithFooter := "_This issue was automatically created by [Allstar](https://github.com/ossf/allstar/)._\n\n**Security Policy Violation**\nStatus text\n\n---\n\nCustomFooter\n\nThis issue will auto resolve when the policy is in compliance.\n\nIssue created by Allstar. See https://github.com/ossf/allstar/ for more information. For questions specific to the repository, please contact the owner or maintainer."
 		listByRepo = func(ctx context.Context, owner string, repo string,
 			opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error) {
 			return make([]*github.Issue, 0), &github.Response{NextPage: 0}, nil


### PR DESCRIPTION
Update generic header for all issues. Add an empty line between custom footer
and standard footer when customer footer is specified. Add break before
footers. Update Binary Artifacts notify text for clarity.

Fix #134 