### PR TITLE
Add option to Org OptConfig to opt-out archived repositories.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,9 @@ type OrgOptConfig struct {
 	// OptOutPublicRepos : set to true to not access public repos.
 	OptOutPublicRepos bool `yaml:"optOutPublicRepos"`
 
+	// OptOutArchivedRepos : set to true to opt-out archived repositories.
+	OptOutArchivedRepos bool `yaml:"optOutArchivedRepos"`
+
 	// DisableRepoOverride : set to true to disallow repos from opt-in/out in
 	// their config.
 	DisableRepoOverride bool `yaml:"disableRepoOverride"`
@@ -184,6 +187,9 @@ func isEnabled(ctx context.Context, o OrgOptConfig, r RepoOptConfig, rep reposit
 			enabled = false
 		}
 		if o.OptOutPublicRepos && !gr.GetPrivate() {
+			enabled = false
+		}
+		if o.OptOutArchivedRepos && gr.GetArchived() {
 			enabled = false
 		}
 		if !o.DisableRepoOverride && r.OptOut {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -180,11 +180,12 @@ optConfig:
 
 func TestIsEnabled(t *testing.T) {
 	tests := []struct {
-		Name          string
-		Org           OrgOptConfig
-		Repo          RepoOptConfig
-		IsPrivateRepo bool
-		Expect        bool
+		Name           string
+		Org            OrgOptConfig
+		Repo           RepoOptConfig
+		IsPrivateRepo  bool
+		IsArchivedRepo bool
+		Expect         bool
 	}{
 		{
 			Name: "OptInOrg",
@@ -266,6 +267,27 @@ func TestIsEnabled(t *testing.T) {
 			Expect:        true,
 		},
 		{
+			Name: "OptOutArchivedRepos",
+			Org: OrgOptConfig{
+				OptOutStrategy:      true,
+				OptOutArchivedRepos: true,
+			},
+			Repo:           RepoOptConfig{},
+			IsPrivateRepo:  true,
+			IsArchivedRepo: true,
+			Expect:         false,
+		},
+		{
+			Name: "NoOptOutArchivedRepos",
+			Org: OrgOptConfig{
+				OptOutStrategy: true,
+			},
+			Repo:           RepoOptConfig{},
+			IsPrivateRepo:  true,
+			IsArchivedRepo: true,
+			Expect:         true,
+		},
+		{
 			Name: "RepoOptIn",
 			Org:  OrgOptConfig{},
 			Repo: RepoOptConfig{
@@ -303,7 +325,8 @@ func TestIsEnabled(t *testing.T) {
 			get = func(context.Context, string, string) (*github.Repository,
 				*github.Response, error) {
 				return &github.Repository{
-					Private: &test.IsPrivateRepo,
+					Private:  &test.IsPrivateRepo,
+					Archived: &test.IsArchivedRepo,
 				}, nil, nil
 			}
 			got, _ := isEnabled(context.Background(), test.Org, test.Repo, mockRepos{}, "thisorg", "thisrepo")


### PR DESCRIPTION
Some admins may want to opt-out all archived repositories from certian
policies, or Allstar as a whole.

Fixes #108 