### PR TITLE
Update branch protection policy to include required status checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/google/go-cmp v0.5.7
-	github.com/google/go-github/v39 v39.2.0
+	github.com/google/go-github/v43 v43.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/ossf/scorecard/v4 v4.0.2-0.20220216001345-ba503c3bee01

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-github/v43 v43.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
-	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/ossf/scorecard/v4 v4.0.2-0.20220216001345-ba503c3bee01
 	github.com/rs/zerolog v1.26.1
 	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228

--- a/go.sum
+++ b/go.sum
@@ -717,10 +717,10 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v38 v38.1.0 h1:C6h1FkaITcBFK7gAmq4eFzt6gbhEhk7L5z6R3Uva+po=
 github.com/google/go-github/v38 v38.1.0/go.mod h1:cStvrz/7nFr0FoENgG6GLbp53WaelXucT+BBz/3VKx4=
-github.com/google/go-github/v39 v39.2.0 h1:rNNM311XtPOz5rDdsJXAp2o8F67X9FnROXTvto3aSnQ=
-github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
+github.com/google/go-github/v43 v43.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
+github.com/google/go-github/v43 v43.0.0/go.mod h1:ZkTvvmCXBvsfPpTHXnH/d2hP9Y0cTbvN9kr5xqyXOIc=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/go.sum
+++ b/go.sum
@@ -1069,8 +1069,6 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.0.0 h1:CcuG/HvWNkkaqCUpJifQY8z7qEMBJya6aLPx6ftGyjQ=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ossf/allstar/pkg/config/operator"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 )
 
 var getContents func(context.Context, string, string, string,

--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ossf/allstar/pkg/policies"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/ossf/allstar/pkg/policydef"
 )
 

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/gregjones/httpcache"
 	"github.com/ossf/allstar/pkg/config/operator"
 	"gocloud.dev/runtimevar"

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/config/operator"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 )
 
 const issueRepoTitle = "Security Policy violation for repository %q %v"

--- a/pkg/issue/issue_test.go
+++ b/pkg/issue/issue_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/config/operator"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 )
 
 var listByRepo func(context.Context, string, string,

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/clients/githubrepo"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -489,6 +489,8 @@ func fix(ctx context.Context, rep repositories, c *github.Client,
 						update = true
 					}
 				}
+				// Clear out Contexts, since API populates both, but updates require only one.
+				pr.RequiredStatusChecks.Contexts = nil
 				pr.RequiredStatusChecks.Checks = make([]*github.RequiredStatusCheck, 0)
 				for _, check := range allContexts {
 					pr.RequiredStatusChecks.Checks = append(pr.RequiredStatusChecks.Checks, check)

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -101,8 +101,7 @@ type RepoConfig struct {
 	// RequireUpToDateBranch overrides the same setting in org-level, only if present.
 	RequireUpToDateBranch *bool `yaml:"requireUpToDateBranch"`
 
-	// RequireStatusChecks is a list of status checks (by name) that are required in
-	// order to merge into the protected branch.
+	// RequireStatusChecks overrides the same setting in org-level, only if present.
 	RequireStatusChecks []string `yaml:"statusChecks"`
 }
 
@@ -557,7 +556,6 @@ func mergeConfig(oc *OrgConfig, rc *RepoConfig, repo string) *mergedConfig {
 		RequireStatusChecks:   oc.RequireStatusChecks,
 	}
 	mc.EnforceBranches = append(mc.EnforceBranches, rc.EnforceBranches...)
-	mc.RequireStatusChecks = append(mc.RequireStatusChecks, rc.RequireStatusChecks...)
 
 	if !oc.OptConfig.DisableRepoOverride {
 		if rc.Action != nil {
@@ -580,6 +578,9 @@ func mergeConfig(oc *OrgConfig, rc *RepoConfig, repo string) *mergedConfig {
 		}
 		if rc.RequireUpToDateBranch != nil {
 			mc.RequireUpToDateBranch = *rc.RequireUpToDateBranch
+		}
+		if rc.RequireStatusChecks != nil {
+			mc.RequireStatusChecks = rc.RequireStatusChecks
 		}
 	}
 	return mc

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -97,11 +97,15 @@ type RepoConfig struct {
 	// BlockForce overrides the same setting in org-level, only if present.
 	BlockForce *bool `yaml:"blockForce"`
 
-	// RequireUpToDateBranch overrides the same setting in org-level, only if present.
+	// RequireUpToDateBranch overrides the same setting in org-level, only if
+	// present.
 	RequireUpToDateBranch *bool `yaml:"requireUpToDateBranch"`
 
-	// RequireStatusChecks overrides the same setting in org-level, only if present.
-	RequireStatusChecks []string `yaml:"statusChecks"`
+	// RequireStatusChecks overrides the same setting in org-level, only if
+	// present. Omitting will lead to taking the org-level config as is, but
+	// specifying an empty list (`requireStatusChecks: []`) will override the
+	// setting to be empty.
+	RequireStatusChecks []string `yaml:"requireStatusChecks"`
 }
 
 type mergedConfig struct {

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -187,6 +187,176 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
+			Name: "CatchRequireUpToDateBranchNoConfig",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:        true,
+				RequireApproval:       true,
+				ApprovalCount:         1,
+				DismissStale:          true,
+				BlockForce:            true,
+				RequireUpToDateBranch: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Require up to date branch not configured for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:             true,
+						NumReviews:            5,
+						DismissStale:          true,
+						BlockForce:            true,
+						RequireUpToDateBranch: false,
+					},
+				},
+			},
+		},
+		{
+			Name: "CatchRequireUpToDateBranchStrictFalse",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:        true,
+				RequireApproval:       true,
+				ApprovalCount:         1,
+				DismissStale:          true,
+				BlockForce:            true,
+				RequireUpToDateBranch: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict: false,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Require up to date branch not configured for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:             true,
+						NumReviews:            5,
+						DismissStale:          true,
+						BlockForce:            true,
+						RequireUpToDateBranch: false,
+					},
+				},
+			},
+		},
+		{
+			Name: "CatchRequireStatusChecksNoConfig",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:      true,
+				RequireApproval:     true,
+				ApprovalCount:       1,
+				DismissStale:        true,
+				BlockForce:          true,
+				RequireStatusChecks: []string{"mycheck", "theothercheck"},
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "No status checks required for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:    true,
+						NumReviews:   5,
+						DismissStale: true,
+						BlockForce:   true,
+					},
+				},
+			},
+		},
+		{
+			Name: "CatchRequireStatusChecks",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:      true,
+				RequireApproval:     true,
+				ApprovalCount:       1,
+				DismissStale:        true,
+				BlockForce:          true,
+				RequireStatusChecks: []string{"mycheck", "theothercheck"},
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   false,
+						Contexts: []string{"mycheck"},
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Status check theothercheck not required for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:           true,
+						NumReviews:          5,
+						DismissStale:        true,
+						BlockForce:          true,
+						RequireStatusChecks: []string{"mycheck"},
+					},
+				},
+			},
+		},
+		{
 			Name: "RepoOverride",
 			Org: OrgConfig{
 				OptConfig: config.OrgOptConfig{
@@ -523,6 +693,112 @@ func TestFix(t *testing.T) {
 					AllowForcePushes: &flse,
 					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
 						RequiredApprovingReviewCount: 0,
+					},
+				},
+			},
+		},
+		{
+			Name: "RequireUpToDateBranchOnly",
+			Org: OrgConfig{
+				EnforceDefault:        true,
+				RequireUpToDateBranch: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						RequiredApprovingReviewCount: 0,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					AllowForcePushes: &flse,
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						RequiredApprovingReviewCount: 0,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   true,
+						Contexts: []string{},
+					},
+				},
+			},
+		},
+		{
+			Name: "RequireStatusChecksOnly",
+			Org: OrgConfig{
+				EnforceDefault:      true,
+				RequireStatusChecks: []string{"mycheck", "theothercheck"},
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						RequiredApprovingReviewCount: 0,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					AllowForcePushes: &flse,
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						RequiredApprovingReviewCount: 0,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   false,
+						Contexts: []string{"mycheck", "theothercheck"},
+					},
+				},
+			},
+		},
+		{
+			Name: "MergeRequireStatusChecks",
+			Org: OrgConfig{
+				EnforceDefault:      true,
+				RequireStatusChecks: []string{"mycheck", "theothercheck"},
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						RequiredApprovingReviewCount: 0,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   false,
+						Contexts: []string{"mycheck", "someothercheck"},
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					AllowForcePushes: &flse,
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						RequiredApprovingReviewCount: 0,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   false,
+						Contexts: []string{"mycheck", "someothercheck", "theothercheck"},
 					},
 				},
 			},

--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 )

--- a/pkg/policies/security/security.go
+++ b/pkg/policies/security/security.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 	"github.com/shurcooL/githubv4"
 )

--- a/pkg/policies/security/security_test.go
+++ b/pkg/policies/security/security_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 	"github.com/ossf/allstar/pkg/config"
 	"github.com/ossf/allstar/pkg/policydef"
 )

--- a/pkg/policydef/policydef.go
+++ b/pkg/policydef/policydef.go
@@ -26,7 +26,7 @@ package policydef
 import (
 	"context"
 
-	"github.com/google/go-github/v39/github"
+	"github.com/google/go-github/v43/github"
 )
 
 // Result is returned from a policy check.


### PR DESCRIPTION
This implements https://github.com/ossf/allstar/issues/30 by introducing the following config settings to `branch_protection.yaml`:

- `requireUpToDateBranch`: Controls whether required status checks should be strict, as defined in [the GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging).
    - Note that (AFAIK) you can enable strict required status checks without any required checks, hence I set this as a separate flag.
    - I defaulted this to `false` for backward compatibility reasons.
- `requireStatusChecks`: List of status checks that should be required for merging.

When operating in fix mode, the following logic is implemented:
- If repo has no required status checks, and `requireUpToDateBranch = true`, enable strict required status checks.
- If repo has no required status checks, and `requireStatusChecks` is non-empty, set required status checks to the desired list.
- If repo has required status checks and strict mode is false but `requireUpToDateBranch = true`, enable strict mode.
- If repo has required status checks and `requireStatusChecks` is non-empty, merge in status check to the existing list, deduping at the end.