### PR TITLE
Allow AWS Secrets Manager as a source for key secret

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,7 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.16.3/go.mod h1:QuiHPBqlOFCi4LqdSskYY
 github.com/aws/aws-sdk-go-v2/service/s3 v1.26.3 h1:rMPtwA7zzkSQZhhz9U3/SoIDz/NZ7Q+iRn4EIO8rSyU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.26.3/go.mod h1:g1qvDuRsJY+XghsV6zg00Z4KJ7DtFFCx8fJD2a491Ak=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.6.0/go.mod h1:B+7C5UKdVq1ylkI/A6O8wcurFtaux0R1njePNPtKwoA=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.4 h1:EmIEXOjAdXtxa2OGM1VAajZV/i06Q8qd4kBpJd9/p1k=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.15.4/go.mod h1:PJc8s+lxyU8rrre0/4a0pn2wgwiDvOEzoOjcJUBr67o=
 github.com/aws/aws-sdk-go-v2/service/sns v1.17.4/go.mod h1:kElt+uCcXxcqFyc+bQqZPFD9DME/eC6oHBXvFzQ9Bcw=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.18.3/go.mod h1:skmQo0UPvsjsuYYSYMVmrPc1HWCbHUJyrCEp+ZaLzqM=
@@ -1006,6 +1007,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=

--- a/operator.md
+++ b/operator.md
@@ -30,11 +30,14 @@ to create and download a private key. Also note down the App ID in the General /
 About section of your new app.
 
 Upload the private key contents to a supported service by [Go CDK Runtime
-Configuration](https://gocloud.dev/howto/runtimevar/)
+Configuration](https://gocloud.dev/howto/runtimevar/).
 
 Edit `pkg/config/operator/operator.go` and set the AppID and KeySecret link. You
 may need to edit `pkg/ghclients/ghclients.go` and add a new import line for your
 secret service, ex: `_ "gocloud.dev/runtimevar/gcpsecretmanager"`.
+
+Alternatively, you can provide the AppID and KeySecret as environment variables
+`APP_ID` and `KEY_SECRET`.
 
 ## Run Allstar.
 

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gregjones/httpcache"
 	"github.com/ossf/allstar/pkg/config/operator"
 	"gocloud.dev/runtimevar"
+	_ "gocloud.dev/runtimevar/awssecretsmanager"
 	_ "gocloud.dev/runtimevar/gcpsecretmanager"
 )
 


### PR DESCRIPTION
Due to company policy reasons, we've been running our own instance of `allstar`. However, we use AWS as our cloud, and the last thing that prevents us from using the upstream package vs our fork is the lack of support for reading the GitHub secrets from something other than GCP secret manager. This PR adds the driver support to use AWS secrets manager as an alternative source for the secret key.

Would be greatly appreciated if we can get this driver import in upstream so we don't have to maintain the fork for our deployments! (but understand if there is a desire to keep the binary light)