### PR TITLE
Disabled should not run anything

### DIFF
--- a/pkg/config/operator/operator.go
+++ b/pkg/config/operator/operator.go
@@ -49,6 +49,15 @@ const RepoConfigDir = ".allstar"
 // AppConfigFile is the name of the expected file in org or repo level config.
 const AppConfigFile = "allstar.yaml"
 
+// DoNothingOnOptOut is a configuration flag indicating if allstar should do
+// nothing and skip the corresponding checks when a repository is opted out.
+// Can be configured with environment variable DO_NOTHING_ON_OPT_OUT, where
+// the value should be a string equivalent of a bool, as accepted by
+// strconv.ParseBool.
+const setDoNothingOnOptOut = false
+
+var DoNothingOnOptOut bool
+
 // GitHubIssueLabel is the label used to tag, search, and identify GitHub
 // Issues created by the bot.
 const GitHubIssueLabel = "allstar"
@@ -83,5 +92,13 @@ func setVars() {
 		KeySecret = keySecret
 	} else {
 		KeySecret = setKeySecret
+	}
+
+	doNothingOnOptOutStr := osGetenv("DO_NOTHING_ON_OPT_OUT")
+	doNothingOnOptOut, err := strconv.ParseBool(doNothingOnOptOutStr)
+	if err == nil {
+		DoNothingOnOptOut = doNothingOnOptOut
+	} else {
+		DoNothingOnOptOut = setDoNothingOnOptOut
 	}
 }

--- a/pkg/config/operator/operator_test.go
+++ b/pkg/config/operator/operator_test.go
@@ -23,32 +23,49 @@ import (
 
 func TestSetVars(t *testing.T) {
 	tests := []struct {
-		Name         string
-		AppID        string
-		KeySecret    string
-		ExpAppID     int64
-		ExpKeySecret string
+		Name                 string
+		AppID                string
+		KeySecret            string
+		DoNothingOnOptOut    string
+		ExpAppID             int64
+		ExpKeySecret         string
+		ExpDoNothingOnOptOut bool
 	}{
 		{
-			Name:         "NoVars",
-			AppID:        "",
-			KeySecret:    "",
-			ExpAppID:     setAppID,
-			ExpKeySecret: setKeySecret,
+			Name:                 "NoVars",
+			AppID:                "",
+			KeySecret:            "",
+			DoNothingOnOptOut:    "",
+			ExpAppID:             setAppID,
+			ExpKeySecret:         setKeySecret,
+			ExpDoNothingOnOptOut: setDoNothingOnOptOut,
 		},
 		{
-			Name:         "SetVars",
-			AppID:        "123",
-			KeySecret:    "asdf",
-			ExpAppID:     123,
-			ExpKeySecret: "asdf",
+			Name:                 "SetVars",
+			AppID:                "123",
+			KeySecret:            "asdf",
+			DoNothingOnOptOut:    "true",
+			ExpAppID:             123,
+			ExpKeySecret:         "asdf",
+			ExpDoNothingOnOptOut: true,
 		},
 		{
-			Name:         "BadInt",
-			AppID:        "notint",
-			KeySecret:    "",
-			ExpAppID:     setAppID,
-			ExpKeySecret: setKeySecret,
+			Name:                 "BadInt",
+			AppID:                "notint",
+			KeySecret:            "",
+			DoNothingOnOptOut:    "",
+			ExpAppID:             setAppID,
+			ExpKeySecret:         setKeySecret,
+			ExpDoNothingOnOptOut: setDoNothingOnOptOut,
+		},
+		{
+			Name:                 "BadBool",
+			AppID:                "",
+			KeySecret:            "",
+			DoNothingOnOptOut:    "not-bool",
+			ExpAppID:             setAppID,
+			ExpKeySecret:         setKeySecret,
+			ExpDoNothingOnOptOut: setDoNothingOnOptOut,
 		},
 	}
 	for _, test := range tests {
@@ -60,6 +77,9 @@ func TestSetVars(t *testing.T) {
 				if in == "KEY_SECRET" {
 					return test.KeySecret
 				}
+				if in == "DO_NOTHING_ON_OPT_OUT" {
+					return test.DoNothingOnOptOut
+				}
 				return ""
 			}
 			setVars()
@@ -67,6 +87,9 @@ func TestSetVars(t *testing.T) {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.ExpKeySecret, KeySecret); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.ExpDoNothingOnOptOut, DoNothingOnOptOut); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -203,6 +203,17 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
+	if !enabled {
+		// Don't run this policy unless enabled. This is only checking enablement
+		// of policy, but not Allstar overall, this is ok for now.
+		return &policydef.Result{
+			Enabled:    enabled,
+			Pass:       true,
+			NotifyText: "Disabled",
+			Details:    map[string]details{},
+		}, nil
+	}
+
 	mc := mergeConfig(oc, rc, repo)
 
 	r, _, err := rep.Get(ctx, owner, repo)

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/ossf/allstar/pkg/config"
+	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
 	"github.com/google/go-github/v43/github"
@@ -152,6 +153,7 @@ var configFetchConfig func(context.Context, *github.Client, string, string,
 	string, bool, interface{}) error
 var configIsEnabled func(ctx context.Context, o config.OrgOptConfig,
 	r config.RepoOptConfig, c *github.Client, owner, repo string) (bool, error)
+var doNothingOnOptOut = operator.DoNothingOnOptOut
 
 func init() {
 	configFetchConfig = config.FetchConfig
@@ -203,9 +205,10 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
-	if !enabled {
-		// Don't run this policy unless enabled. This is only checking enablement
-		// of policy, but not Allstar overall, this is ok for now.
+	if !enabled && doNothingOnOptOut {
+		// Don't run this policy if disabled and requested by operator. This is
+		// only checking enablement of policy, but not Allstar overall, this is
+		// ok for now.
 		return &policydef.Result{
 			Enabled:    enabled,
 			Pass:       true,

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -90,15 +90,8 @@ func TestCheck(t *testing.T) {
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
-				NotifyText: "",
-				Details: map[string]details{
-					"main": details{
-						PRReviews:    true,
-						NumReviews:   1,
-						DismissStale: true,
-						BlockForce:   true,
-					},
-				},
+				NotifyText: "Disabled",
+				Details:    map[string]details{},
 			},
 		},
 		{

--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -20,11 +20,14 @@ import (
 	"fmt"
 
 	"github.com/ossf/allstar/pkg/config"
+	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 )
+
+var doNothingOnOptOut = operator.DoNothingOnOptOut
 
 const configFile = "outside.yaml"
 const polName = "Outside Collaborators"
@@ -161,9 +164,10 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
-	if !enabled {
-		// Don't run this policy unless enabled. This is only checking enablement
-		// of policy, but not Allstar overall, this is ok for now.
+	if !enabled && doNothingOnOptOut {
+		// Don't run this policy if disabled and requested by operator. This is
+		// only checking enablement of policy, but not Allstar overall, this is
+		// ok for now.
 		return &policydef.Result{
 			Enabled:    enabled,
 			Pass:       true,

--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -161,6 +161,17 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
+	if !enabled {
+		// Don't run this policy unless enabled. This is only checking enablement
+		// of policy, but not Allstar overall, this is ok for now.
+		return &policydef.Result{
+			Enabled:    enabled,
+			Pass:       true,
+			NotifyText: "Disabled",
+			Details:    details{},
+		}, nil
+	}
+
 	mc := mergeConfig(oc, rc, repo)
 
 	var d details

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -64,7 +64,7 @@ func TestCheck(t *testing.T) {
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
-				NotifyText: "",
+				NotifyText: "Disabled",
 				Details:    details{},
 			},
 		},

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -44,13 +44,14 @@ func TestCheck(t *testing.T) {
 	bob := "bob"
 	alice := "alice"
 	tests := []struct {
-		Name         string
-		Org          OrgConfig
-		Repo         RepoConfig
-		Users        []*github.User
-		cofigEnabled bool
-		Exp          policydef.Result
-		Teams        []*github.Team
+		Name              string
+		Org               OrgConfig
+		Repo              RepoConfig
+		Users             []*github.User
+		cofigEnabled      bool
+		doNothingOnOptOut bool
+		Exp               policydef.Result
+		Teams             []*github.Team
 	}{
 		{
 			Name: "NotEnabled",
@@ -58,9 +59,27 @@ func TestCheck(t *testing.T) {
 				PushAllowed:             true,
 				TestingOwnerlessAllowed: true,
 			},
-			Repo:         RepoConfig{},
-			Users:        nil,
-			cofigEnabled: false,
+			Repo:              RepoConfig{},
+			Users:             nil,
+			cofigEnabled:      false,
+			doNothingOnOptOut: false,
+			Exp: policydef.Result{
+				Enabled:    false,
+				Pass:       true,
+				NotifyText: "",
+				Details:    details{},
+			},
+		},
+		{
+			Name: "NotEnabledDoNothing",
+			Org: OrgConfig{
+				PushAllowed:             true,
+				TestingOwnerlessAllowed: true,
+			},
+			Repo:              RepoConfig{},
+			Users:             nil,
+			cofigEnabled:      false,
+			doNothingOnOptOut: true,
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
@@ -77,9 +96,10 @@ func TestCheck(t *testing.T) {
 				PushAllowed:             true,
 				TestingOwnerlessAllowed: true,
 			},
-			Repo:         RepoConfig{},
-			Users:        nil,
-			cofigEnabled: true,
+			Repo:              RepoConfig{},
+			Users:             nil,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -111,7 +131,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled: true,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -147,7 +168,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled: true,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -186,7 +208,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled: true,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -225,7 +248,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled: true,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -279,7 +303,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled: true,
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -317,6 +342,7 @@ func TestCheck(t *testing.T) {
 				c *github.Client, owner, repo string) (bool, error) {
 				return test.cofigEnabled, nil
 			}
+			doNothingOnOptOut = test.doNothingOnOptOut
 			listTeams = func(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
 				return test.Teams, &github.Response{NextPage: 0}, nil
 			}

--- a/pkg/policies/security/security.go
+++ b/pkg/policies/security/security.go
@@ -114,6 +114,16 @@ func check(ctx context.Context, c *github.Client, v4c v4client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
+	if !enabled {
+		// Don't run this policy unless enabled. This is only checking enablement
+		// of policy, but not Allstar overall, this is ok for now.
+		return &policydef.Result{
+			Enabled:    enabled,
+			Pass:       true,
+			NotifyText: "Disabled",
+			Details:    details{},
+		}, nil
+	}
 
 	var q struct {
 		Repository struct {

--- a/pkg/policies/security/security.go
+++ b/pkg/policies/security/security.go
@@ -20,12 +20,15 @@ import (
 	"fmt"
 
 	"github.com/ossf/allstar/pkg/config"
+	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 	"github.com/shurcooL/githubv4"
 )
+
+var doNothingOnOptOut = operator.DoNothingOnOptOut
 
 const configFile = "security.yaml"
 const polName = "SECURITY.md"
@@ -114,9 +117,10 @@ func check(ctx context.Context, c *github.Client, v4c v4client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
-	if !enabled {
-		// Don't run this policy unless enabled. This is only checking enablement
-		// of policy, but not Allstar overall, this is ok for now.
+	if !enabled && doNothingOnOptOut {
+		// Don't run this policy if disabled and requested by operator. This is
+		// only checking enablement of policy, but not Allstar overall, this is
+		// ok for now.
 		return &policydef.Result{
 			Enabled:    enabled,
 			Pass:       true,

--- a/pkg/policies/security/security_test.go
+++ b/pkg/policies/security/security_test.go
@@ -50,11 +50,8 @@ func TestCheck(t *testing.T) {
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
-				NotifyText: "",
-				Details: details{
-					Enabled: true,
-					URL:     "",
-				},
+				NotifyText: "Disabled",
+				Details:    details{},
 			},
 		},
 		{

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -133,6 +133,16 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
+	if !enabled {
+		// Don't run this policy unless enabled. This is only checking enablement
+		// of policy, but not Allstar overall, this is ok for now.
+		return &policydef.Result{
+			Enabled:    enabled,
+			Pass:       true,
+			NotifyText: "Disabled",
+			Details:    details{},
+		}, nil
+	}
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/ossf/allstar/pkg/config"
+	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 	"github.com/ossf/allstar/pkg/scorecard"
 	"github.com/ossf/scorecard/v4/checker"
@@ -29,6 +30,8 @@ import (
 	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
 )
+
+var doNothingOnOptOut = operator.DoNothingOnOptOut
 
 const configFile = "dangerous_workflow.yaml"
 const polName = "Dangerous Workflow"
@@ -133,9 +136,10 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
-	if !enabled {
-		// Don't run this policy unless enabled. This is only checking enablement
-		// of policy, but not Allstar overall, this is ok for now.
+	if !enabled && doNothingOnOptOut {
+		// Don't run this policy if disabled and requested by operator. This is
+		// only checking enablement of policy, but not Allstar overall, this is
+		// ok for now.
 		return &policydef.Result{
 			Enabled:    enabled,
 			Pass:       true,


### PR DESCRIPTION
Fixes https://github.com/ossf/allstar/issues/171

This PR updates all the policies to disable the check completely when it is not enabled via the config, like the `Binary Artifacts` check.

I see now that this was implemented this way because the other checks are relatively quick to run, but as mentioned on the issue, it is probably a good idea to bypass the checks if not needed to run to reduce API calls and avoid hitting rate limits.