### PR TITLE
Add debug logging around cache utilization

### DIFF
--- a/pkg/config/operator/operator.go
+++ b/pkg/config/operator/operator.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // AppID should be set to the application ID of the created GitHub App. See:
@@ -57,6 +59,16 @@ const AppConfigFile = "allstar.yaml"
 const setDoNothingOnOptOut = false
 
 var DoNothingOnOptOut bool
+
+// LogLevel is a configuration flag indicating the minimum logging level that
+// allstar should use when emitting logs. Can be configured with the environment
+// variable ALLSTAR_LOG_LEVEL, which must be one of the following strings:
+// panic ; fatal ; error ; warn ; info ; debug ; trace
+// If an unparsable string is provided, then allstar will automatically default
+// to info level.
+const setLogLevel = zerolog.InfoLevel
+
+var LogLevel zerolog.Level
 
 // GitHubIssueLabel is the label used to tag, search, and identify GitHub
 // Issues created by the bot.
@@ -101,4 +113,13 @@ func setVars() {
 	} else {
 		DoNothingOnOptOut = setDoNothingOnOptOut
 	}
+
+	logLevelStr := osGetenv("ALLSTAR_LOG_LEVEL")
+	logLevel, err := zerolog.ParseLevel(logLevelStr)
+	if err == nil {
+		LogLevel = logLevel
+	} else {
+		LogLevel = setLogLevel
+	}
+	zerolog.SetGlobalLevel(LogLevel)
 }

--- a/pkg/config/operator/operator.go
+++ b/pkg/config/operator/operator.go
@@ -116,10 +116,10 @@ func setVars() {
 
 	logLevelStr := osGetenv("ALLSTAR_LOG_LEVEL")
 	logLevel, err := zerolog.ParseLevel(logLevelStr)
-	if err == nil {
-		LogLevel = logLevel
-	} else {
+	if err != nil || logLevel == zerolog.NoLevel {
 		LogLevel = setLogLevel
+	} else {
+		LogLevel = logLevel
 	}
 	zerolog.SetGlobalLevel(LogLevel)
 }

--- a/pkg/ghclients/memorycache.go
+++ b/pkg/ghclients/memorycache.go
@@ -40,6 +40,12 @@ func (c *memoryCache) Get(key string) (resp []byte, ok bool) {
 	c.mu.RLock()
 	resp, ok = c.items[key]
 	c.mu.RUnlock()
+
+	log.Debug().
+		Str("area", "bot").
+		Str("key", key).
+		Msg("Cache GET request")
+
 	return resp, ok
 }
 
@@ -48,6 +54,11 @@ func (c *memoryCache) Set(key string, resp []byte) {
 	c.mu.Lock()
 	c.items[key] = resp
 	c.mu.Unlock()
+
+	log.Debug().
+		Str("area", "bot").
+		Str("key", key).
+		Msg("Cache SET request")
 }
 
 // Delete removes key from the cache
@@ -55,6 +66,11 @@ func (c *memoryCache) Delete(key string) {
 	c.mu.Lock()
 	delete(c.items, key)
 	c.mu.Unlock()
+
+	log.Debug().
+		Str("area", "bot").
+		Str("key", key).
+		Msg("Cache DELETE request")
 }
 
 func (c *memoryCache) LogCacheSize() {
@@ -65,6 +81,7 @@ func (c *memoryCache) LogCacheSize() {
 	log.Info().
 		Str("area", "bot").
 		Int("size", total).
+		Int("items", len(c.items)).
 		Msg("Total cache size.")
 }
 


### PR DESCRIPTION
This PR adds additional debug logging in the cache functions at the DEBUG log level so that they don't normally show up in the runtime logs. This was very useful in understanding how the cache was being used.

Additionally, this introduces a new operator configuration flag that can be used to control the log level of the `allstar` deployment.