### PR TITLE
Allow org-level configs to specify a base repo to merge configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,41 @@ For example, Allstar will lookup the policy configuration for a given repo
 | `.github` | `allstar/myapp/branch_protection.yaml` | If `.allstar` repo does not exist. |
 | `.github` | `allstar/branch_protection.yaml` | If `.allstar` repo does not exist. |
 
+### Org-level Base and Merge Configuration Location
+
+For org-level Allstar and policy configuration files, you may specify the field
+`baseConfig` to specify another repository that contains base Allstar
+configuration. This is best explained with an example.
+
+Suppose you have multiple GitHub organizations, but want to maintain a single
+Allstar configuration. Your main organization is "acme", and the repository
+`acme/.allstar` contains `allstar.yaml`:
+
+```yaml
+optConfig:
+  optOutStrategy: true
+issueLabel: allstar-acme
+issueFooter: Issue created by Acme security team.
+```
+
+You also have a satellite GitHub organization named "acme-sat". You want to
+re-use the main config, but apply some changes on top by disabling Allstar on
+certain repositories. The repository `acme-sat/.allstar` contains
+`allstar.yaml`:
+
+```yaml
+baseConfig: acme/.allstar
+optConfig:
+  optOutRepos:
+  - acmesat-one
+  - acmesat-two
+```
+
+This will use all the config from `acme/.allstar` as the base config, but then
+apply any changes in the current file on top of the base configuration. The
+method this is applied is described as a [JSON Merge
+Patch](https://datatracker.ietf.org/doc/html/rfc7396). The `baseConfig` must be
+a GitHub `<org>/<repository>`.
 
 ## **Contribute Policies**
 

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/rs/zerolog v1.26.1
 	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228
 	gocloud.dev v0.25.0
-	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v43 v43.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.sum
+++ b/go.sum
@@ -2366,5 +2366,7 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 sourcegraph.com/sqs/pbtypes v1.0.0/go.mod h1:3AciMUv4qUuRHRHhOG4TZOB+72GdPVz5k+c648qsFS4=

--- a/go.sum
+++ b/go.sum
@@ -590,6 +590,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,18 +24,18 @@ import (
 
 	"github.com/google/go-github/v43/github"
 	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // OrgConfig is the org-level config definition for Allstar
 type OrgConfig struct {
 	// OptConfig contains the opt in/out configuration.
-	OptConfig OrgOptConfig `yaml:"optConfig"`
+	OptConfig OrgOptConfig `json:"optConfig"`
 
 	// IssueLabel is the label used to tag, search, and identify GitHub Issues
 	// created by the bot. The defeault is specified by the operator of Allstar,
 	// currently: "allstar"
-	IssueLabel string `yaml:"issueLabel"`
+	IssueLabel string `json:"issueLabel"`
 
 	// IssueRepo is the name of a repository in the organization to create issues
 	// in. If left unset, by default Allstar will create issues in the repository
@@ -49,7 +49,7 @@ type OrgConfig struct {
 	//
 	// Note: When changing this setting, Allstar does not clean up previously
 	// created issues from a previous setting.
-	IssueRepo string `yaml:"issueRepo"`
+	IssueRepo string `json:"issueRepo"`
 
 	// IssueFooter is a custom message to add to the end of all Allstar created
 	// issues in the GitHub organization. It does not supercede the bot-level
@@ -57,54 +57,54 @@ type OrgConfig struct {
 	// one. This setting is useful to direct users to the organization-level
 	// config repository or documentation describing your Allstar settings and
 	// policies.
-	IssueFooter string `yaml:"issueFooter"`
+	IssueFooter string `json:"issueFooter"`
 }
 
 // OrgOptConfig is used in Allstar and policy-secific org-level config to
 // define the opt in/out configuration.
 type OrgOptConfig struct {
 	// OptOutStrategy : set to true to change from opt-in to opt-out.
-	OptOutStrategy bool `yaml:"optOutStrategy"`
+	OptOutStrategy bool `json:"optOutStrategy"`
 
 	// OptInRepos is the list of repos to opt-in when in opt-in strategy.
-	OptInRepos []string `yaml:"optInRepos"`
+	OptInRepos []string `json:"optInRepos"`
 
 	// OptOutRepos is the list of repos to opt-out when in opt-out strategy.
-	OptOutRepos []string `yaml:"optOutRepos"`
+	OptOutRepos []string `json:"optOutRepos"`
 
 	// OptOutPrivateRepos : set to true to not access private repos.
-	OptOutPrivateRepos bool `yaml:"optOutPrivateRepos"`
+	OptOutPrivateRepos bool `json:"optOutPrivateRepos"`
 
 	// OptOutPublicRepos : set to true to not access public repos.
-	OptOutPublicRepos bool `yaml:"optOutPublicRepos"`
+	OptOutPublicRepos bool `json:"optOutPublicRepos"`
 
 	// OptOutArchivedRepos : set to true to opt-out archived repositories.
-	OptOutArchivedRepos bool `yaml:"optOutArchivedRepos"`
+	OptOutArchivedRepos bool `json:"optOutArchivedRepos"`
 
 	// DisableRepoOverride : set to true to disallow repos from opt-in/out in
 	// their config.
-	DisableRepoOverride bool `yaml:"disableRepoOverride"`
+	DisableRepoOverride bool `json:"disableRepoOverride"`
 }
 
 // RepoConfig is the repo-level config definition for Allstar
 type RepoConfig struct {
 	// OptConfig contains the opt in/out configuration.
-	OptConfig RepoOptConfig `yaml:"optConfig"`
+	OptConfig RepoOptConfig `json:"optConfig"`
 
 	// IssueLabel is the label used to tag, search, and identify GitHub Issues
 	// created by the bot. Repo-level label my override Org-level setting
 	// regardless of Optconfig.DisableRepoOverride.
-	IssueLabel string `yaml:"issueLabel"`
+	IssueLabel string `json:"issueLabel"`
 }
 
 // RepoOptConfig is used in Allstar and policy-specific repo-level config to
 // opt in/out of enforcement.
 type RepoOptConfig struct {
 	// OptIn : set to true to opt-in this repo when in opt-in strategy
-	OptIn bool `yaml:"optIn"`
+	OptIn bool `json:"optIn"`
 
 	// OptOut: set to true to opt-out this repo when in opt-out strategy
-	OptOut bool `yaml:"optOut"`
+	OptOut bool `json:"optOut"`
 }
 
 const githubConfRepo = ".github"

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -38,30 +38,30 @@ const polName = "Binary Artifacts"
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride applies to all
 	// config.
-	OptConfig config.OrgOptConfig `yaml:"optConfig"`
+	OptConfig config.OrgOptConfig `json:"optConfig"`
 
 	// Action defines which action to take, default log, other: issue...
-	Action string `yaml:"action"`
+	Action string `json:"action"`
 
 	// IgnoreFiles is a list of file names to ignore. Any Binary Artifacts found
 	// with these names are allowed, and the policy may still pass. These are
 	// just the file name, not a full path. Globs are not allowed.
-	IgnoreFiles []string `yaml:"ignoreFiles"`
+	IgnoreFiles []string `json:"ignoreFiles"`
 }
 
 // RepoConfig is the repo-level config for this policy.
 type RepoConfig struct {
 	// OptConfig is the standard repo-level opt in/out config.
-	OptConfig config.RepoOptConfig `yaml:"optConfig"`
+	OptConfig config.RepoOptConfig `json:"optConfig"`
 
 	// Action overrides the same setting in org-level, only if present.
-	Action *string `yaml:"action"`
+	Action *string `json:"action"`
 
 	// IgnorePaths is a list of full paths to ignore. If these are reported as a
 	// Binary Artifact, they will be ignored and the policy may still pass. These
 	// must be full paths with directories. Globs are not allowed. These are
 	// allowed even if RepoOverride is false.
-	IgnorePaths []string `yaml:"ignorePaths"`
+	IgnorePaths []string `json:"ignorePaths"`
 }
 
 type mergedConfig struct {

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -35,92 +35,92 @@ const polName = "Branch Protection"
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride
 	// applies to all BP config.
-	OptConfig config.OrgOptConfig `yaml:"optConfig"`
+	OptConfig config.OrgOptConfig `json:"optConfig"`
 
 	// Action defines which action to take, default log, other: issue...
-	Action string `yaml:"action"`
+	Action string `json:"action"`
 
 	// EnforceDefault : set to true to enforce policy on default branch, default
 	// true.
-	EnforceDefault bool `yaml:"enforceDefault"`
+	EnforceDefault bool `json:"enforceDefault"`
 
 	// EnforceBranches is a map of repos and branches. These are other
 	// non-default branches to enforce policy on, such as branches which releases
 	// are made from.
-	EnforceBranches map[string][]string `yaml:"enforceBranches"`
+	EnforceBranches map[string][]string `json:"enforceBranches"`
 
 	// RequireApproval : set to true to enforce approval on PRs, default true.
-	RequireApproval bool `yaml:"requireApproval"`
+	RequireApproval bool `json:"requireApproval"`
 
 	// ApprovalCount is the number of required PR approvals, default 1.
-	ApprovalCount int `yaml:"approvalCount"`
+	ApprovalCount int `json:"approvalCount"`
 
 	// DismissStale : set to true to require PR approvals be dismissed when a PR
 	// is updated, default true.
-	DismissStale bool `yaml:"dismissStale"`
+	DismissStale bool `json:"dismissStale"`
 
 	// BlockForce : set to true to block force pushes, default true.
-	BlockForce bool `yaml:"blockForce"`
+	BlockForce bool `json:"blockForce"`
 
 	// RequireUpToDateBranch : set to true to require that branches must be up
 	// to date before merging. Only used if RequireStatusChecks is set. Default
 	// true.
-	RequireUpToDateBranch bool `yaml:"requireUpToDateBranch"`
+	RequireUpToDateBranch bool `json:"requireUpToDateBranch"`
 
 	// RequireStatusChecks is a list of status checks that are required in
 	// order to merge into the protected branch. Each entry must specify
 	// the context, and optionally an appID.
-	RequireStatusChecks []StatusCheck `yaml:"requireStatusChecks"`
+	RequireStatusChecks []StatusCheck `json:"requireStatusChecks"`
 }
 
 // RepoConfig is the repo-level config for Branch Protection
 type RepoConfig struct {
 	// OptConfig is the standard repo-level opt in/out config.
-	OptConfig config.RepoOptConfig `yaml:"optConfig"`
+	OptConfig config.RepoOptConfig `json:"optConfig"`
 
 	// Action overrides the same setting in org-level, only if present.
-	Action *string `yaml:"action"`
+	Action *string `json:"action"`
 
 	// EnforceDefault overrides the same setting in org-level, only if present.
-	EnforceDefault *bool `yaml:"enforceDefault"`
+	EnforceDefault *bool `json:"enforceDefault"`
 
 	// EnforceBranches adds more branches to the org-level list. Does not
 	// override. Always allowed irrespective of DisableRepoOverride setting.
-	EnforceBranches []string `yaml:"enforceBranches"`
+	EnforceBranches []string `json:"enforceBranches"`
 
 	// RequireApproval overrides the same setting in org-level, only if present.
-	RequireApproval *bool `yaml:"requireApproval"`
+	RequireApproval *bool `json:"requireApproval"`
 
 	// ApprovalCount overrides the same setting in org-level, only if present.
-	ApprovalCount *int `yaml:"approvalCount"`
+	ApprovalCount *int `json:"approvalCount"`
 
 	// DismissStale overrides the same setting in org-level, only if present.
-	DismissStale *bool `yaml:"dismissStale"`
+	DismissStale *bool `json:"dismissStale"`
 
 	// BlockForce overrides the same setting in org-level, only if present.
-	BlockForce *bool `yaml:"blockForce"`
+	BlockForce *bool `json:"blockForce"`
 
 	// RequireUpToDateBranch overrides the same setting in org-level, only if
 	// present.
-	RequireUpToDateBranch *bool `yaml:"requireUpToDateBranch"`
+	RequireUpToDateBranch *bool `json:"requireUpToDateBranch"`
 
 	// RequireStatusChecks overrides the same setting in org-level, only if
 	// present. Omitting will lead to taking the org-level config as is, but
 	// specifying an empty list (`requireStatusChecks: []`) will override the
 	// setting to be empty.
-	RequireStatusChecks []StatusCheck `yaml:"requireStatusChecks"`
+	RequireStatusChecks []StatusCheck `json:"requireStatusChecks"`
 }
 
 // StatusCheck is the config description for specifying a single required
 // status check in the RequireStatusChecks list.
 type StatusCheck struct {
 	// Context is the status check name that should be required.
-	Context string `yaml:"context"`
+	Context string `json:"context"`
 
 	// AppID, when provided, will require that the status check be set by
 	// the GitHub App with the given AppID. When omitted, any app can
 	// provide the required status check.
-	AppID *int64 `yaml:"appID"`
+	AppID *int64 `json:"appID"`
 }
 
 type statusCheckHash struct {

--- a/pkg/policies/outside/outside.go
+++ b/pkg/policies/outside/outside.go
@@ -60,41 +60,41 @@ Alternately, if this repository does not have any maintainers, archive or delete
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride
 	// applies to all config.
-	OptConfig config.OrgOptConfig `yaml:"optConfig"`
+	OptConfig config.OrgOptConfig `json:"optConfig"`
 
 	// Action defines which action to take, default log, other: issue...
-	Action string `yaml:"action"`
+	Action string `json:"action"`
 
 	// PushAllowed defined if outside collaboraters are allowed to have push
 	// access, default true.
-	PushAllowed bool `yaml:"pushAllowed"`
+	PushAllowed bool `json:"pushAllowed"`
 
 	// AdminAllowed defined if outside collaboraters are allowed to have admin
 	// access, default false.
-	AdminAllowed bool `yaml:"adminAllowed"`
+	AdminAllowed bool `json:"adminAllowed"`
 
 	// TestingOwnerlessAllowed defined if repositories are allowed to have no
 	// administrators, default false.
-	TestingOwnerlessAllowed bool `yaml:"testingOwnerlessAllowed"`
+	TestingOwnerlessAllowed bool `json:"testingOwnerlessAllowed"`
 }
 
 // RepoConfig is the repo-level config for Outside Collaborators security
 // policy.
 type RepoConfig struct {
 	// OptConfig is the standard repo-level opt in/out config.
-	OptConfig config.RepoOptConfig `yaml:"optConfig"`
+	OptConfig config.RepoOptConfig `json:"optConfig"`
 
 	// Action overrides the same setting in org-level, only if present.
-	Action *string `yaml:"action"`
+	Action *string `json:"action"`
 
 	// PushAllowed overrides the same setting in org-level, only if present.
-	PushAllowed *bool `yaml:"pushAllowed"`
+	PushAllowed *bool `json:"pushAllowed"`
 
 	// AdminAllowed overrides the same setting in org-level, only if present.
-	AdminAllowed *bool `yaml:"adminAllowed"`
+	AdminAllowed *bool `json:"adminAllowed"`
 
 	// TestingOwnerlessAllowed overrides the same setting in org-level, only if present.
-	TestingOwnerlessAllowed *bool `yaml:"testingOwnerlessAllowed"`
+	TestingOwnerlessAllowed *bool `json:"testingOwnerlessAllowed"`
 }
 
 type mergedConfig struct {

--- a/pkg/policies/security/security.go
+++ b/pkg/policies/security/security.go
@@ -43,10 +43,10 @@ For more information, see https://docs.github.com/en/code-security/getting-start
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride applies to all
 	// BP config.
-	OptConfig config.OrgOptConfig `yaml:"optConfig"`
+	OptConfig config.OrgOptConfig `json:"optConfig"`
 
 	// Action defines which action to take, default log, other: issue...
-	Action string `yaml:"action"`
+	Action string `json:"action"`
 
 	//TODO add default contents for "fix" action
 }
@@ -54,10 +54,10 @@ type OrgConfig struct {
 // RepoConfig is the repo-level config for Branch Protection
 type RepoConfig struct {
 	// OptConfig is the standard repo-level opt in/out config.
-	OptConfig config.RepoOptConfig `yaml:"optConfig"`
+	OptConfig config.RepoOptConfig `json:"optConfig"`
 
 	// Action overrides the same setting in org-level, only if present.
-	Action *string `yaml:"action"`
+	Action *string `json:"action"`
 }
 
 type mergedConfig struct {

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -40,19 +40,19 @@ const polName = "Dangerous Workflow"
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride applies to all
 	// config.
-	OptConfig config.OrgOptConfig `yaml:"optConfig"`
+	OptConfig config.OrgOptConfig `json:"optConfig"`
 
 	// Action defines which action to take, default log, other: issue...
-	Action string `yaml:"action"`
+	Action string `json:"action"`
 }
 
 // RepoConfig is the repo-level config for this policy.
 type RepoConfig struct {
 	// OptConfig is the standard repo-level opt in/out config.
-	OptConfig config.RepoOptConfig `yaml:"optConfig"`
+	OptConfig config.RepoOptConfig `json:"optConfig"`
 
 	// Action overrides the same setting in org-level, only if present.
-	Action *string `yaml:"action"`
+	Action *string `json:"action"`
 }
 
 type mergedConfig struct {


### PR DESCRIPTION
Any org-level file can set "baseConfig" to a GitHub "owner/repo". Then the same
file in that repo will be read first, and the contents of the current file will
be applied on top of the baseConfig as a RFC7396 JSON merge patch:
https://datatracker.ietf.org/doc/html/rfc7396.