### PR TITLE
Update logic in getting config files to avoid hitting 404s.

### DIFF
--- a/pkg/config/contents.go
+++ b/pkg/config/contents.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Allstar Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path"
+
+	"github.com/google/go-github/v43/github"
+)
+
+func walkGetContents(ctx context.Context, r repositories, owner, repo, p string,
+	opt *github.RepositoryContentGetOptions) (*github.RepositoryContent,
+	[]*github.RepositoryContent, *github.Response, error) {
+	paths := makePaths(p)
+	for _, v := range paths {
+		dir, file := path.Split(v)
+		_, rcs, rsp, err := r.GetContents(ctx, owner, repo, dir, opt)
+		if rcs == nil || err != nil {
+			return nil, nil, rsp, err
+		}
+		if !fileExists(file, rcs) {
+			return nil, nil, &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}, errors.New("Not found")
+		}
+	}
+	// File should exist
+	return r.GetContents(ctx, owner, repo, p, opt)
+}
+
+func makePaths(p string) []string {
+	var rv []string
+	current := p
+	rv = append(rv, current)
+	for path.Dir(current) != "." {
+		rv = append(rv, path.Dir(current))
+		current = path.Dir(current)
+	}
+	for i, j := 0, len(rv)-1; i < j; i, j = i+1, j-1 {
+		rv[i], rv[j] = rv[j], rv[i]
+	}
+	return rv
+}
+
+func fileExists(file string, rcs []*github.RepositoryContent) bool {
+	for _, rc := range rcs {
+		if file == rc.GetName() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/location.go
+++ b/pkg/config/location.go
@@ -1,0 +1,94 @@
+// Copyright 2021 Allstar Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ossf/allstar/pkg/config/operator"
+)
+
+type instLoc struct {
+	Exists bool
+	Repo   string
+	Path   string
+}
+
+var instLocs map[string]*instLoc
+
+// Function getInstLoc gets the location of org-level configuration for this
+// org/installation. The purpose is to only hit possible 404s once per run.
+func getInstLoc(ctx context.Context, r repositories, owner string) (*instLoc, error) {
+	if instLocs == nil {
+		instLocs = make(map[string]*instLoc)
+	}
+	if il, ok := instLocs[owner]; ok {
+		return il, nil
+	}
+	il, err := createIl(ctx, r, owner)
+	if err != nil {
+		return nil, err
+	}
+	instLocs[owner] = il
+	return il, nil
+}
+
+// Function ClearInstLoc clears any saved config locations for an org/installation
+func ClearInstLoc(owner string) {
+	if instLocs == nil {
+		return
+	}
+	if _, ok := instLocs[owner]; !ok {
+		return
+	}
+	delete(instLocs, owner)
+}
+
+func createIl(ctx context.Context, r repositories, owner string) (*instLoc, error) {
+	_, rsp, err := r.Get(ctx, owner, operator.OrgConfigRepo)
+	if err == nil {
+		// ".allstar" repo exists
+		return &instLoc{
+			Exists: true,
+			Repo:   operator.OrgConfigRepo,
+			Path:   "",
+		}, nil
+	} else if rsp != nil && rsp.StatusCode == http.StatusNotFound {
+		// ".allstar" repo does not exist
+		_, rsp, err := r.Get(ctx, owner, githubConfRepo)
+		if err == nil {
+			// ".github" repo exists
+			// ".github/allstar" may not exist but we will walk the path on any
+			// getcontents to avoid a 404 for that
+			return &instLoc{
+				Exists: true,
+				Repo:   githubConfRepo,
+				Path:   operator.OrgConfigDir,
+			}, nil
+		} else if rsp != nil && rsp.StatusCode == http.StatusNotFound {
+			// ".github" repo does not exist
+			return &instLoc{
+				Exists: false,
+			}, nil
+		} else {
+			// Unknown error getting ".github" repo
+			return nil, err
+		}
+	} else {
+		// Unknown error getting ".allstar" repo
+		return nil, err
+	}
+}

--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -113,11 +113,15 @@ func EnforceAll(ctx context.Context, ghc *ghclients.GHClients) error {
 			Int("count", len(repos)).
 			Msg("Enforcing policies on repos of installation.")
 		repoCount = repoCount + len(repos)
+		var owner string
 		for _, r := range repos {
 			enabled := config.IsBotEnabled(ctx, ic, *r.Owner.Login, *r.Name)
 			err = RunPolicies(ctx, ic, *r.Owner.Login, *r.Name, enabled)
 			if err != nil {
 				break
+			}
+			if owner == "" {
+				owner = *r.Owner.Login
 			}
 		}
 		if err != nil {
@@ -126,6 +130,7 @@ func EnforceAll(ctx context.Context, ghc *ghclients.GHClients) error {
 				Msg("Unexpected error running policies.")
 			continue
 		}
+		config.ClearInstLoc(owner)
 	}
 	ghc.LogCacheSize()
 	log.Info().


### PR DESCRIPTION
Config files can reside in multiple places, and Allstar needs to look for them
for each repository. We have a local cache and use GitHub conditonal requests
to preserve quota. However, 404s don't work with cache or conditonal
requests. Therefore we should avoid 404s where possible. This change includes
two parts:

1. Preserve whether or not the ".allstar" or ".github" repositories exist
across an installation run. We can't avoid 404s if we don't do this. Each
config file lookup for each repo would need to do a get on both of these if
they don't exist.

2. When looking for a file, start at the repo top level, and get the directory
listing, then see if the file exists before trying to get the file. The
directory listing should exist at least at the top level, so we can cache that
and also use conditional requests.