### PR TITLE
New feature: Log summary of enforce results

### DIFF
--- a/cmd/allstar/main.go
+++ b/cmd/allstar/main.go
@@ -46,7 +46,7 @@ func main() {
 	flag.Parse()
 
 	if *boolArgPtr {
-		err := enforce.EnforceAll(ctx, ghc)
+		_, err := enforce.EnforceAll(ctx, ghc)
 		if err != nil {
 			log.Fatal().
 				Err(err).

--- a/pkg/config/operator/operator.go
+++ b/pkg/config/operator/operator.go
@@ -29,6 +29,10 @@ const setAppID = 119816
 
 var AppID int64
 
+// Raw value of the private key for the App. See:
+// https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-private-key
+var PrivateKey string
+
 // KeySecret should be set to the name of a secret containing a private key for
 // the App. See:
 // https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-private-key
@@ -100,6 +104,8 @@ func setVars() {
 	} else {
 		AppID = setAppID
 	}
+
+	PrivateKey = osGetenv("PRIVATE_KEY")
 
 	keySecret := osGetenv("KEY_SECRET")
 	if keySecret != "" {

--- a/pkg/config/operator/operator_test.go
+++ b/pkg/config/operator/operator_test.go
@@ -27,11 +27,13 @@ func TestSetVars(t *testing.T) {
 		Name                  string
 		AppID                 string
 		KeySecret             string
-		DoNothingOnOptOut     string
 		NoticePingDurationHrs string
+		PrivateKey            string
+		DoNothingOnOptOut     string
 		ExpAppID              int64
 		ExpKeySecret          string
 		ExpDoNothingOnOptOut  bool
+		ExpPrivateKey         string
 		ExpNoticePingDuration time.Duration
 	}{
 		{
@@ -75,6 +77,18 @@ func TestSetVars(t *testing.T) {
 			ExpNoticePingDuration: (24 * time.Hour),
 		},
 		{
+			Name:                  "HasPrivateKey",
+			AppID:                 "",
+			KeySecret:             "",
+			PrivateKey:            "fake-private-key",
+			DoNothingOnOptOut:     "",
+			ExpAppID:              setAppID,
+			ExpKeySecret:          setKeySecret,
+			ExpDoNothingOnOptOut:  setDoNothingOnOptOut,
+			ExpPrivateKey:         "fake-private-key",
+			ExpNoticePingDuration: (24 * time.Hour),
+		},
+		{
 			Name:                  "SetNoticePingDuration",
 			AppID:                 "",
 			KeySecret:             "",
@@ -101,6 +115,9 @@ func TestSetVars(t *testing.T) {
 				if in == "NOTICE_PING_DURATION_HOURS" {
 					return test.NoticePingDurationHrs
 				}
+				if in == "PRIVATE_KEY" {
+					return test.PrivateKey
+				}
 				return ""
 			}
 			setVars()
@@ -114,6 +131,9 @@ func TestSetVars(t *testing.T) {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(test.ExpNoticePingDuration, NoticePingDuration); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.PrivateKey, PrivateKey); diff != "" {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -16,15 +16,21 @@ package enforce
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v43/github"
+	"github.com/ossf/allstar/pkg/ghclients"
 	"github.com/ossf/allstar/pkg/policydef"
 )
 
-var result policydef.Result
+var policy1Results policyRepoResults
+var policy2Results policyRepoResults
 var action string
 var fixCalled bool
+
+type policyRepoResults map[string]policydef.Result
 
 type pol struct{}
 
@@ -33,7 +39,8 @@ func (p pol) Name() string {
 }
 
 func (p pol) Check(ctx context.Context, c *github.Client, owner, repo string) (*policydef.Result, error) {
-	return &result, nil
+	policy1Result := policy1Results[repo]
+	return &policy1Result, nil
 }
 
 func (p pol) Fix(ctx context.Context, c *github.Client, owner, repo string) error {
@@ -42,6 +49,25 @@ func (p pol) Fix(ctx context.Context, c *github.Client, owner, repo string) erro
 }
 
 func (p pol) GetAction(ctx context.Context, c *github.Client, owner, repo string) string {
+	return action
+}
+
+type pol2 struct{}
+
+func (p pol2) Name() string {
+	return "Test policy2"
+}
+
+func (p pol2) Check(ctx context.Context, c *github.Client, owner, repo string) (*policydef.Result, error) {
+	policy2Result := policy2Results[repo]
+	return &policy2Result, nil
+}
+
+func (p pol2) Fix(ctx context.Context, c *github.Client, owner, repo string) error {
+	return nil
+}
+
+func (p pol2) GetAction(ctx context.Context, c *github.Client, owner, repo string) string {
 	return action
 }
 
@@ -61,53 +87,78 @@ func TestRunPolicies(t *testing.T) {
 		closeCalled = true
 		return nil
 	}
+	repo := "fake-repo"
 	tests := []struct {
-		Name         string
-		Res          policydef.Result
-		Action       string
-		ShouldFix    bool
-		ShouldEnsure bool
-		ShouldClose  bool
+		Name              string
+		Res               policyRepoResults
+		Action            string
+		ShouldFix         bool
+		ShouldEnsure      bool
+		ShouldClose       bool
+		ExpEnforceResults EnforceResults
 	}{
 		{
-			Name:         "LogOnly",
-			Res:          policydef.Result{Enabled: true, Pass: false},
+			Name: "LogOnly",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: true, Pass: false},
+			},
 			Action:       "log",
 			ShouldFix:    false,
 			ShouldEnsure: false,
 			ShouldClose:  false,
+			ExpEnforceResults: EnforceResults{
+				"Test policy": false,
+			},
 		},
 		{
-			Name:         "OpenIssue",
-			Res:          policydef.Result{Enabled: true, Pass: false},
+			Name: "OpenIssue",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: true, Pass: false},
+			},
 			Action:       "issue",
 			ShouldFix:    false,
 			ShouldEnsure: true,
 			ShouldClose:  false,
+			ExpEnforceResults: EnforceResults{
+				"Test policy": false,
+			},
 		},
 		{
-			Name:         "CloseIssue",
-			Res:          policydef.Result{Enabled: true, Pass: true},
+			Name: "CloseIssue",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: true, Pass: true},
+			},
 			Action:       "issue",
 			ShouldFix:    false,
 			ShouldEnsure: false,
 			ShouldClose:  true,
+			ExpEnforceResults: EnforceResults{
+				"Test policy": true,
+			},
 		},
 		{
-			Name:         "Fix",
-			Res:          policydef.Result{Enabled: true, Pass: false},
+			Name: "Fix",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: true, Pass: false},
+			},
 			Action:       "fix",
 			ShouldFix:    true,
 			ShouldEnsure: false,
 			ShouldClose:  false,
+			ExpEnforceResults: EnforceResults{
+				"Test policy": false,
+			},
 		},
 		{
-			Name:         "PolicyDisabled",
-			Res:          policydef.Result{Enabled: false, Pass: false},
-			Action:       "fix",
-			ShouldFix:    false,
-			ShouldEnsure: false,
-			ShouldClose:  false,
+			Name: "PolicyDisabled",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: false, Pass: false},
+			},
+			Action:            "fix",
+			ShouldFix:         false,
+			ShouldEnsure:      false,
+			ShouldClose:       false,
+			ExpEnforceResults: EnforceResults{},
 		},
 	}
 	for _, test := range tests {
@@ -115,9 +166,9 @@ func TestRunPolicies(t *testing.T) {
 			fixCalled = false
 			ensureCalled = false
 			closeCalled = false
-			result = test.Res
+			policy1Results = test.Res
 			action = test.Action
-			err := RunPolicies(context.Background(), nil, "", "", true)
+			enforceResults, err := RunPolicies(context.Background(), nil, "", repo, true)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -142,10 +193,209 @@ func TestRunPolicies(t *testing.T) {
 					t.Error("Close called unexpectedly.")
 				}
 			}
+			if diff := cmp.Diff(test.ExpEnforceResults, enforceResults); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
 		})
 	}
 }
 
+type MockGhClients struct{}
+
+func (m MockGhClients) Get(i int64) (*github.Client, error) {
+	return github.NewClient(&http.Client{Transport: http.DefaultTransport}), nil
+}
+
+func (m MockGhClients) LogCacheSize() {}
+
 func TestEnforceAll(t *testing.T) {
-	t.Skip("Testing EnforceAll looks tricky, TODO")
+	policiesGetPolicies = func() []policydef.Policy {
+		return []policydef.Policy{
+			pol{},
+			pol2{},
+		}
+	}
+	issueEnsure = func(ctx context.Context, c *github.Client, owner, repo, policy, text string) error {
+		return nil
+	}
+	issueClose = func(ctx context.Context, c *github.Client, owner, repo, policy string) error {
+		return nil
+	}
+	getAppInstallations = func(ctx context.Context, ghc ghclients.GhClientsInterface) ([]*github.Installation, error) {
+		var insts []*github.Installation
+		appID := int64(123456)
+		inst := &github.Installation{
+			ID: &appID,
+		}
+		insts = append(insts, inst)
+		return insts, nil
+	}
+	getAppInstallationRepos = func(ctx context.Context, ghc ghclients.GhClientsInterface, ic *github.Client) ([]*github.Repository, error) {
+		var repos []*github.Repository
+		repo1Name := "repo1"
+		repo2Name := "repo2"
+		ownerLogin := "fake-owner"
+		newRepos := []*github.Repository{
+			{
+				Name: &repo1Name,
+				Owner: &github.User{
+					Login: &ownerLogin,
+				},
+			},
+			{
+				Name: &repo2Name,
+				Owner: &github.User{
+					Login: &ownerLogin,
+				},
+			},
+		}
+		repos = append(repos, newRepos...)
+		return repos, nil
+	}
+	isBotEnabled = func(ctx context.Context, c *github.Client, owner, repo string) bool {
+		return true
+	}
+
+	mockGhc := &MockGhClients{}
+	action = "log"
+
+	type EnforceTest struct {
+		Name           string
+		Policy1Results policyRepoResults
+		Policy2Results policyRepoResults
+		ExpResults     EnforceAllResults
+	}
+	tests := []EnforceTest{
+		{
+			Name: "SinglePolicySingleRepoFailed",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: true},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 1,
+				},
+			},
+		},
+		{
+			Name: "SinglePolicyBothReposFailed",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: true},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 2,
+				},
+			},
+		},
+		{
+			Name: "BothPolicySingleRepoFailed",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 1,
+				},
+				"Test policy2": {
+					"totalFailed": 1,
+				},
+			},
+		},
+		{
+			Name: "BothPoliciesBothReposPassed",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: true},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: true},
+				"repo2": {Enabled: true, Pass: true},
+			},
+			ExpResults: EnforceAllResults{},
+		},
+		{
+			Name: "BothPoliciesSingleRepoDisabled",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: false, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: false, Pass: false},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 1,
+				},
+				"Test policy2": {
+					"totalFailed": 1,
+				},
+			},
+		},
+		{
+			Name: "SinglePolicyBothReposDisabled",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: false, Pass: false},
+				"repo2": {Enabled: false, Pass: false},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 2,
+				},
+			},
+		},
+		{
+			Name: "BothPoliciesBothReposFailed",
+			Policy1Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			Policy2Results: policyRepoResults{
+				"repo1": {Enabled: true, Pass: false},
+				"repo2": {Enabled: true, Pass: false},
+			},
+			ExpResults: EnforceAllResults{
+				"Test policy": {
+					"totalFailed": 2,
+				},
+				"Test policy2": {
+					"totalFailed": 2,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			policy1Results = test.Policy1Results
+			policy2Results = test.Policy2Results
+			enforceAllResults, err := EnforceAll(context.Background(), mockGhc)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(test.ExpResults, enforceAllResults); diff != "" {
+				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -41,6 +41,11 @@ func init() {
 	getKey = getKeyReal
 }
 
+type GhClientsInterface interface {
+	Get(i int64) (*github.Client, error)
+	LogCacheSize()
+}
+
 // GHClients stores clients per-installation for re-use througout a process.
 type GHClients struct {
 	clients map[int64]*github.Client


### PR DESCRIPTION
This PR adds code to generate a summary of how many repos failed the check for each policy. The summary looks something like this when logged:

```json
 {"severity":"INFO","area":"bot","count":20,
"results":{"Branch Protection":{"totalFailed":3},"Outside Collaborators":{"totalFailed":2}},
"time":"2022-06-09T16:16:23Z","message":"EnforceAll complete."}
```

This feature is useful for me as I configure and test Allstar because it gives me a preview of how many Github issues would be created if I set `action: issue`. It may also be just be a generally useful summary to have.

I also refactored the code slightly to allow unit testing `EnforceAll`.