### PR TITLE
Load key from env var

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -605,6 +605,7 @@ github.com/frankban/quicktest v1.13.1 h1:xVm/f9seEhZFL9+n5kv5XLrGwy6elc4V9v/XFY2
 github.com/frankban/quicktest v1.13.1/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=

--- a/operator.md
+++ b/operator.md
@@ -30,16 +30,19 @@ to create and download a private key. Also note down the App ID in the General /
 About section of your new app.
 
 Upload the private key contents to a supported service by [Go CDK Runtime
-Configuration](https://gocloud.dev/howto/runtimevar/).
+Configuration](https://gocloud.dev/howto/runtimevar/). Also note, the Runtime
+Configuration library will support a local file as well.
 
-Edit `pkg/config/operator/operator.go` and set the AppID and KeySecret link. You
-may need to edit `pkg/ghclients/ghclients.go` and add a new import line for your
-secret service, ex: `_ "gocloud.dev/runtimevar/gcpsecretmanager"`.
+Edit `pkg/config/operator/operator.go` and set the AppID and KeySecret
+link. Alternatively, you can provide the AppID and KeySecret as environment
+variables `APP_ID` and `KEY_SECRET`. You may need to edit
+`pkg/ghclients/ghclients.go` and add a new import line for your secret service,
+ex: `_ "gocloud.dev/runtimevar/gcpsecretmanager"`.
 
-Alternatively, you can provide the AppID and KeySecret as environment variables
-`APP_ID` and `KEY_SECRET`. Or, you can provide the private key directly in the
-environment variable `PRIVATE_KEY` instead of using a secret service. If you
-specify `PRIVATE_KEY` and `KEY_SECRET`, `PRIVATE_KEY` will take precedence.
+> **Warning, this is not a recommended practice for security.** If you are
+  not using a supported runtime you may provide the contents of the private key
+  directly in the environment variable `PRIVATE_KEY`. Allstar will only use this
+  if the contents of `KEY_SECRET` is set exactly to `direct`.
 
 ## Run Allstar.
 

--- a/operator.md
+++ b/operator.md
@@ -37,7 +37,9 @@ may need to edit `pkg/ghclients/ghclients.go` and add a new import line for your
 secret service, ex: `_ "gocloud.dev/runtimevar/gcpsecretmanager"`.
 
 Alternatively, you can provide the AppID and KeySecret as environment variables
-`APP_ID` and `KEY_SECRET`.
+`APP_ID` and `KEY_SECRET`. Or, you can provide the private key directly in the
+environment variable `PRIVATE_KEY` instead of using a secret service. If you
+specify `PRIVATE_KEY` and `KEY_SECRET`, `PRIVATE_KEY` will take precedence.
 
 ## Run Allstar.
 

--- a/pkg/config/operator/operator_test.go
+++ b/pkg/config/operator/operator_test.go
@@ -27,6 +27,7 @@ func TestSetVars(t *testing.T) {
 		Name                  string
 		AppID                 string
 		KeySecret             string
+		PrivateKey            string
 		NoticePingDurationHrs string
 		PrivateKey            string
 		DoNothingOnOptOut     string
@@ -98,6 +99,18 @@ func TestSetVars(t *testing.T) {
 			ExpKeySecret:          setKeySecret,
 			ExpDoNothingOnOptOut:  setDoNothingOnOptOut,
 			ExpNoticePingDuration: (48 * time.Hour),
+		},
+		{
+			Name:                  "HasPrivateKey",
+			AppID:                 "",
+			KeySecret:             "",
+			PrivateKey:            "fake-private-key",
+			DoNothingOnOptOut:     "",
+			ExpAppID:              setAppID,
+			ExpKeySecret:          setKeySecret,
+			ExpDoNothingOnOptOut:  setDoNothingOnOptOut,
+			ExpPrivateKey:         "fake-private-key",
+			ExpNoticePingDuration: (24 * time.Hour),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/config/operator/operator_test.go
+++ b/pkg/config/operator/operator_test.go
@@ -27,7 +27,6 @@ func TestSetVars(t *testing.T) {
 		Name                  string
 		AppID                 string
 		KeySecret             string
-		PrivateKey            string
 		NoticePingDurationHrs string
 		PrivateKey            string
 		DoNothingOnOptOut     string

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ossf/allstar/pkg/config/operator"
 	"gocloud.dev/runtimevar"
 	_ "gocloud.dev/runtimevar/awssecretsmanager"
+	_ "gocloud.dev/runtimevar/filevar"
 	_ "gocloud.dev/runtimevar/gcpsecretmanager"
 )
 
@@ -120,7 +121,7 @@ func getKeyFromSecretReal(ctx context.Context, keySecretVal string) ([]byte, err
 }
 
 func getKeyReal(ctx context.Context) ([]byte, error) {
-	if privateKey != "" {
+	if keySecret == "direct" {
 		return []byte(privateKey), nil
 	}
 	return getKeyFromSecret(ctx, keySecret)

--- a/pkg/ghclients/ghclients_test.go
+++ b/pkg/ghclients/ghclients_test.go
@@ -95,7 +95,7 @@ func TestGetKey(t *testing.T) {
 	}{
 		{
 			Name:       "HasOnlyPrivateKey",
-			KeySecret:  "",
+			KeySecret:  "direct",
 			PrivateKey: "foo",
 			ExpKey:     "foo",
 		},
@@ -109,7 +109,7 @@ func TestGetKey(t *testing.T) {
 			Name:       "HasPrivateKeyAndSecret",
 			KeySecret:  "foo",
 			PrivateKey: "bar",
-			ExpKey:     "bar",
+			ExpKey:     "foo",
 		},
 	}
 


### PR DESCRIPTION
Some doc changes on top of #203 and switch the priority to only use `PRIVATE_KEY` if `KEY_SECRET` is set to `direct`. Also added `gocloud.dev/runtimevar/filevar` to prepare for anyone using a file.

cc @markdboyd 