### PR TITLE
Add configuration option to set enforce_admins for required status checks

### DIFF
--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -331,7 +331,7 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 			}
 		}
 		ea := p.GetEnforceAdmins()
-		d.EnforceOnAdmins = false
+		d.EnforceOnAdmins = (ea != nil && ea.Enabled)
 		if mc.EnforceOnAdmins && (ea == nil || !ea.Enabled) {
 			text = text +
 				fmt.Sprintf("Enforce status checks on admins not configured for branch %v\n",
@@ -417,6 +417,9 @@ func fix(ctx context.Context, rep repositories, c *github.Client,
 				afp := !mc.BlockForce
 				pr := &github.ProtectionRequest{
 					AllowForcePushes: &afp,
+				}
+				if mc.EnforceOnAdmins {
+					pr.EnforceAdmins = true
 				}
 				if mc.RequireApproval {
 					rq := &github.PullRequestReviewsEnforcementRequest{

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -292,7 +292,6 @@ func TestCheck(t *testing.T) {
 				Details:    map[string]details{},
 			},
 		},
-
 		{
 			Name: "CatchBlockForce",
 			Org: OrgConfig{
@@ -660,6 +659,95 @@ func TestCheck(t *testing.T) {
 						DismissStale:        true,
 						BlockForce:          true,
 						RequireStatusChecks: []StatusCheck{{"mycheck", github.Int64(654321)}},
+					},
+				},
+			},
+		},
+		{
+			Name: "CatchEnforceAdminsAdminEnforcementNil",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   1,
+				DismissStale:    true,
+				BlockForce:      true,
+				EnforceOnAdmins: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+				},
+			},
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Enforce status checks on admins not configured for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:             true,
+						NumReviews:            5,
+						DismissStale:          true,
+						BlockForce:            true,
+						RequireUpToDateBranch: false,
+						EnforceOnAdmins:       false,
+					},
+				},
+			},
+		},
+		{
+			Name: "CatchEnforceAdminsAdminEnforcementDisabled",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   1,
+				DismissStale:    true,
+				BlockForce:      true,
+				EnforceOnAdmins: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 5,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+				},
+			},
+			cofigEnabled:      true,
+			doNothingOnOptOut: false,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Enforce status checks on admins not configured for branch main\n",
+				Details: map[string]details{
+					"main": details{
+						PRReviews:             true,
+						NumReviews:            5,
+						DismissStale:          true,
+						BlockForce:            true,
+						RequireUpToDateBranch: false,
+						EnforceOnAdmins:       false,
 					},
 				},
 			},
@@ -1085,6 +1173,37 @@ func TestFix(t *testing.T) {
 						Checks: []*github.RequiredStatusCheck{
 							{Context: "mycheck"}, {Context: "theothercheck"},
 						},
+					},
+				},
+			},
+		},
+		{
+			Name: "EnforceAdmins",
+			Org: OrgConfig{
+				EnforceDefault:  true,
+				EnforceOnAdmins: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						RequiredApprovingReviewCount: 0,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					AllowForcePushes: github.Bool(false),
+					EnforceAdmins:    true,
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						RequiredApprovingReviewCount: 0,
 					},
 				},
 			},

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -1027,6 +1027,30 @@ func TestFix(t *testing.T) {
 			},
 		},
 		{
+			Name: "AddProtectionFromScratch",
+			Org: OrgConfig{
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   2,
+				DismissStale:    true,
+				BlockForce:      true,
+				EnforceOnAdmins: true,
+			},
+			Repo:         RepoConfig{},
+			Prot:         map[string]github.Protection{},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					EnforceAdmins:    true,
+					AllowForcePushes: github.Bool(false),
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 2,
+					},
+				},
+			},
+		},
+		{
 			Name: "NotEnabled",
 			Org: OrgConfig{
 				EnforceDefault:  true,


### PR DESCRIPTION
This PR introduces a new configuration option for the branch protection policy to allow enforcing the "Include Administrators" flag on the branch protection rule (see attached screenshot):

<img width="503" alt="Screen Shot 2022-06-15 at 5 06 18 PM" src="https://user-images.githubusercontent.com/430092/173940399-c096ff0b-9716-47fa-b2ac-aca9212d9f78.png">