### PR TITLE
Fix codeql error

### DIFF
--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -1312,7 +1312,7 @@ func TestFix(t *testing.T) {
 			for _, pr := range got {
 				if pr.RequiredStatusChecks != nil {
 					sc := make([]*github.RequiredStatusCheck, 0)
-					cm := make(map[string][]*github.RequiredStatusCheck, 0)
+					cm := make(map[string][]*github.RequiredStatusCheck)
 					for _, check := range pr.RequiredStatusChecks.Checks {
 						cm[check.Context] = append(cm[check.Context], check)
 					}


### PR DESCRIPTION
I noticed this CodeQL error showing up on the PRs (e.g., see https://github.com/ossf/allstar/pull/214/files#diff-cdd0ff6a2de17b55bf03ccbd18711fad90d3bf84efabebbb98d80d2db5867a0d). This PR should fix that.