### PR TITLE
Avoid GitHub issue where an installation is not working.

### DIFF
--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -230,7 +230,7 @@ func TestEnforceAll(t *testing.T) {
 		insts = append(insts, inst)
 		return insts, nil
 	}
-	getAppInstallationRepos = func(ctx context.Context, ghc ghclients.GhClientsInterface, ic *github.Client) ([]*github.Repository, error) {
+	getAppInstallationRepos = func(ctx context.Context, ghc ghclients.GhClientsInterface, ic *github.Client) ([]*github.Repository, *github.Response, error) {
 		var repos []*github.Repository
 		repo1Name := "repo1"
 		repo2Name := "repo2"
@@ -250,7 +250,7 @@ func TestEnforceAll(t *testing.T) {
 			},
 		}
 		repos = append(repos, newRepos...)
-		return repos, nil
+		return repos, nil, nil
 	}
 	isBotEnabled = func(ctx context.Context, c *github.Client, owner, repo string) bool {
 		return true


### PR DESCRIPTION
For some reason, Allstar has an installation that is coming back from "List
Installations", but when we try a call for that one, we can't get a token. It
returns a 403. Skip for now. Seems like a GitHub bug.