### PR TITLE
Update Allstar to close issues when action: "fix"

### DIFF
--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -248,7 +248,7 @@ func RunPolicies(ctx context.Context, c *github.Client, owner, repo string, enab
 					Msg("Unknown action configured.")
 			}
 		}
-		if r.Pass && a == "issue" {
+		if r.Pass && (a == "issue" || a == "fix") {
 			err := issueClose(ctx, c, owner, repo, p.Name())
 			if err != nil {
 				return nil, err

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -150,6 +150,19 @@ func TestRunPolicies(t *testing.T) {
 			},
 		},
 		{
+			Name: "CloseIssueOnFix",
+			Res: policyRepoResults{
+				"fake-repo": policydef.Result{Enabled: true, Pass: true},
+			},
+			Action:       "fix",
+			ShouldFix:    false,
+			ShouldEnsure: false,
+			ShouldClose:  true,
+			ExpEnforceResults: EnforceResults{
+				"Test policy": true,
+			},
+		},
+		{
 			Name: "PolicyDisabled",
 			Res: policyRepoResults{
 				"fake-repo": policydef.Result{Enabled: false, Pass: false},


### PR DESCRIPTION
Related to #159 

Currently, this experience is possible:

- Action is set to "issue". Allstar runs scans, finds repos out of compliance, and creates Github issues
- Action is set to "fix" to automatically fix the failing repos, but the Github issues remain open unless you set action back to "issue" and wait for the scans to re-run

If action is set to "fix", then for a given repo I would like to see this behavior:

- On initial scan, issues with repo are automatically fixed
- Subsequent scan of the repo closes Github issues, if any

I can't really think of a downside this approach, so I went ahead and implemented it