### PR TITLE
Add logic for repo with empty checks/context

### DIFF
--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -458,6 +458,12 @@ func fix(ctx context.Context, rep repositories, c *github.Client,
 		if pr.RequiredStatusChecks != nil {
 			// Clear out Contexts, since API populates both, but updates require only one.
 			pr.RequiredStatusChecks.Contexts = nil
+			// If there are no actual checks or contexts, then unset RequiredStatusChecks entirely,
+			// otherwise update fails
+			if len(pr.RequiredStatusChecks.Checks) == 0 && len(pr.RequiredStatusChecks.Contexts) == 0 {
+				update = true
+				pr.RequiredStatusChecks = nil
+			}
 		}
 		if p.RequiredPullRequestReviews != nil {
 			prr := &github.PullRequestReviewsEnforcementRequest{

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -1252,6 +1252,45 @@ func TestFix(t *testing.T) {
 			cofigEnabled: true,
 			Exp:          map[string]github.ProtectionRequest{},
 		},
+		{
+			Name: "HandleExistingEmptyChecks",
+			Org: OrgConfig{
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   1,
+				DismissStale:    true,
+				BlockForce:      true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": github.Protection{
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: false,
+					},
+					EnforceAdmins: &github.AdminEnforcement{
+						Enabled: false,
+					},
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 1,
+					},
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict: false,
+					},
+				},
+			},
+			cofigEnabled: true,
+			Exp: map[string]github.ProtectionRequest{
+				"main": github.ProtectionRequest{
+					AllowForcePushes: github.Bool(false),
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 1,
+					},
+					RequiredStatusChecks: nil,
+				},
+			},
+		},
 	}
 	get = func(context.Context, string, string) (*github.Repository,
 		*github.Response, error) {


### PR DESCRIPTION
One of my repos was returning a 422 error from Github and the error logged by Allstar was:

```json
{
    "severity": "ERROR",
    "error": "PUT https://api.github.com/repos/owner/repo/branches/master/protection: 422 Invalid request.\n\nNo subschema in \"anyOf\" matched.\nNo subschema in \"oneOf\" matched.\nNot all subschemas of \"allOf\" matched.\nFor 'anyOf/1', {\"strict\"=>true} is not a null. []",
    "time": "2022-06-17T15: 27: 42Z",
    "message": "Unexpected error running policies."
}
```

After some investigation, I found that if I did a GET request for the branch protection settings, then part of the response was:

```json
    "required_status_checks": {
        "url": "https://api.github.com/repos/owner/repo/branches/master/protection/required_status_checks",
        "strict": true,
        "contexts": [],
        "contexts_url": "https://api.github.com/repos/owner/repo/branches/master/protection/required_status_checks/contexts",
        "checks": []
    },
```

Then I confirmed submitting a PUT request with this partial body does indeed generate the 422 error seen by Allstar:

```
    "required_status_checks": {
        "strict": true,
        "contexts": [],
        "checks": []
    },
```

Somehow this repo was in a state where status checks were returned by the GET request as empty arrays and when those empty status checks were passed along by Allstar to the PUT request for branch protection settings, resulting in the error.  The problem has the same symptoms as #155 but a different cause.

I have no idea how a repo gets into this state - perhaps when a status check registered by another app is removed but the branch protection settings don't get updated to unset required status checks? This repo pre-dates my time at my current job, so I can't really speak to the history in this case.

Regardless, it was causing Allstar to fail and seems like something others could see, so I went ahead and fixed it. I can confirm that with these changes, the repo was updated successfully and my scans were able to continue.