### PR TITLE
Parallize enforcements of installations 5x.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/rs/zerolog v1.27.0
 	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228
 	gocloud.dev v0.25.0
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	sigs.k8s.io/yaml v1.3.0
 )


### PR DESCRIPTION
In order to address performance, run 5 installations at the same time. Each
installation is still synchronous, so this should not affect quotas or enable
simultaneous requests for one installation.