### PR TITLE
Skip policy evaluation if the repo is not enabled

### DIFF
--- a/pkg/policies/action/action.go
+++ b/pkg/policies/action/action.go
@@ -208,6 +208,13 @@ func (a Action) Name() string {
 	return polName
 }
 
+// Check whether this policy is enabled or not
+func (a Action) IsEnabled(ctx context.Context, c *github.Client, owner, repo string) (bool, error) {
+	oc := getConfig(ctx, c, owner, repo)
+	enabled := oc.Groups != nil
+	return enabled, nil
+}
+
 // Check performs the policy check for Action Use policy based on the
 // configuration stored in the org, implementing policydef.Policy.Check()
 func (a Action) Check(ctx context.Context, c *github.Client, owner,

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 
 	"github.com/ossf/allstar/pkg/config"
-	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
 
 	"github.com/google/go-github/v43/github"
@@ -179,7 +178,6 @@ type details struct {
 var configFetchConfig func(context.Context, *github.Client, string, string, string, config.ConfigLevel, interface{}) error
 var configIsEnabled func(ctx context.Context, o config.OrgOptConfig,
 	orc, r config.RepoOptConfig, c *github.Client, owner, repo string) (bool, error)
-var doNothingOnOptOut = operator.DoNothingOnOptOut
 
 func init() {
 	configFetchConfig = config.FetchConfig
@@ -215,6 +213,12 @@ type repositories interface {
 		*github.SignaturesProtectedBranch, *github.Response, error)
 }
 
+// Check whether this policy is enabled or not
+func (b Branch) IsEnabled(ctx context.Context, c *github.Client, owner, repo string) (bool, error) {
+	oc, orc, rc := getConfig(ctx, c, owner, repo)
+	return configIsEnabled(ctx, oc.OptConfig, orc.OptConfig, rc.OptConfig, c, owner, repo)
+}
+
 // Check performs the policy check for Branch Protection based on the
 // configuration stored in the org/repo, implementing policydef.Policy.Check()
 func (b Branch) Check(ctx context.Context, c *github.Client, owner,
@@ -235,17 +239,6 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		Str("area", polName).
 		Bool("enabled", enabled).
 		Msg("Check repo enabled")
-	if !enabled && doNothingOnOptOut {
-		// Don't run this policy if disabled and requested by operator. This is
-		// only checking enablement of policy, but not Allstar overall, this is
-		// ok for now.
-		return &policydef.Result{
-			Enabled:    enabled,
-			Pass:       true,
-			NotifyText: "Disabled",
-			Details:    map[string]details{},
-		}, nil
-	}
 
 	mc := mergeConfig(oc, orc, rc, repo)
 

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -298,14 +298,13 @@ func TestGetSignatureProtectionEnabled(t *testing.T) {
 
 func TestCheck(t *testing.T) {
 	tests := []struct {
-		Name              string
-		Org               OrgConfig
-		Repo              RepoConfig
-		Prot              map[string]github.Protection
-		SigProtection     map[string]github.SignaturesProtectedBranch
-		cofigEnabled      bool
-		doNothingOnOptOut bool
-		Exp               policydef.Result
+		Name          string
+		Org           OrgConfig
+		Repo          RepoConfig
+		Prot          map[string]github.Protection
+		SigProtection map[string]github.SignaturesProtectedBranch
+		cofigEnabled  bool
+		Exp           policydef.Result
 	}{
 		{
 			Name: "NotEnabled",
@@ -330,8 +329,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      false,
-			doNothingOnOptOut: false,
+			cofigEnabled: false,
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
@@ -344,33 +342,6 @@ func TestCheck(t *testing.T) {
 						BlockForce:   true,
 					},
 				},
-			},
-		},
-		{
-			Name: "NotEnabledDoNothing",
-			Org: OrgConfig{
-				EnforceDefault:  true,
-				RequireApproval: true,
-				ApprovalCount:   1,
-				DismissStale:    true,
-				BlockForce:      true,
-			},
-			Repo: RepoConfig{},
-			Prot: map[string]github.Protection{
-				"main": github.Protection{
-					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
-						DismissStaleReviews:          true,
-						RequiredApprovingReviewCount: 1,
-					},
-				},
-			},
-			cofigEnabled:      false,
-			doNothingOnOptOut: true,
-			Exp: policydef.Result{
-				Enabled:    false,
-				Pass:       true,
-				NotifyText: "Disabled",
-				Details:    map[string]details{},
 			},
 		},
 		{
@@ -402,8 +373,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -450,8 +420,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -502,8 +471,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -558,8 +526,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -610,8 +577,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -664,8 +630,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -717,8 +682,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -770,8 +734,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -817,8 +780,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -868,8 +830,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -915,8 +876,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -961,8 +921,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -996,8 +955,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -1037,8 +995,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -1079,8 +1036,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(true),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -1121,8 +1077,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -1158,9 +1113,8 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			SigProtection:     map[string]github.SignaturesProtectedBranch{},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			SigProtection: map[string]github.SignaturesProtectedBranch{},
+			cofigEnabled:  true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -1201,8 +1155,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -1244,8 +1197,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -1286,8 +1238,7 @@ func TestCheck(t *testing.T) {
 					Enabled: github.Bool(false),
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -1362,7 +1313,6 @@ func TestCheck(t *testing.T) {
 				c *github.Client, owner, repo string) (bool, error) {
 				return test.cofigEnabled, nil
 			}
-			doNothingOnOptOut = test.doNothingOnOptOut
 			res, err := check(context.Background(), mockRepos{}, nil, "", "thisrepo")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/pkg/policies/outside/outside_test.go
+++ b/pkg/policies/outside/outside_test.go
@@ -167,14 +167,13 @@ func TestCheck(t *testing.T) {
 	bob := "bob"
 	alice := "alice"
 	tests := []struct {
-		Name              string
-		Org               OrgConfig
-		Repo              RepoConfig
-		Users             []*github.User
-		cofigEnabled      bool
-		doNothingOnOptOut bool
-		Exp               policydef.Result
-		Teams             []*github.Team
+		Name         string
+		Org          OrgConfig
+		Repo         RepoConfig
+		Users        []*github.User
+		cofigEnabled bool
+		Exp          policydef.Result
+		Teams        []*github.Team
 	}{
 		{
 			Name: "NotEnabled",
@@ -182,31 +181,13 @@ func TestCheck(t *testing.T) {
 				PushAllowed:             true,
 				TestingOwnerlessAllowed: true,
 			},
-			Repo:              RepoConfig{},
-			Users:             nil,
-			cofigEnabled:      false,
-			doNothingOnOptOut: false,
+			Repo:         RepoConfig{},
+			Users:        nil,
+			cofigEnabled: false,
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
 				NotifyText: "",
-				Details:    details{},
-			},
-		},
-		{
-			Name: "NotEnabledDoNothing",
-			Org: OrgConfig{
-				PushAllowed:             true,
-				TestingOwnerlessAllowed: true,
-			},
-			Repo:              RepoConfig{},
-			Users:             nil,
-			cofigEnabled:      false,
-			doNothingOnOptOut: true,
-			Exp: policydef.Result{
-				Enabled:    false,
-				Pass:       true,
-				NotifyText: "Disabled",
 				Details:    details{},
 			},
 		},
@@ -219,10 +200,9 @@ func TestCheck(t *testing.T) {
 				PushAllowed:             true,
 				TestingOwnerlessAllowed: true,
 			},
-			Repo:              RepoConfig{},
-			Users:             nil,
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			Repo:         RepoConfig{},
+			Users:        nil,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -254,8 +234,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -291,8 +270,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -331,8 +309,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -371,8 +348,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -426,8 +402,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -468,8 +443,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -506,8 +480,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -545,8 +518,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -584,8 +556,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -622,8 +593,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -657,8 +627,7 @@ func TestCheck(t *testing.T) {
 					},
 				},
 			},
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -692,7 +661,6 @@ func TestCheck(t *testing.T) {
 				c *github.Client, owner, repo string) (bool, error) {
 				return test.cofigEnabled, nil
 			}
-			doNothingOnOptOut = test.doNothingOnOptOut
 			listTeams = func(ctx context.Context, owner string, repo string, opts *github.ListOptions) ([]*github.Team, *github.Response, error) {
 				return test.Teams, &github.Response{NextPage: 0}, nil
 			}

--- a/pkg/policies/security/security_test.go
+++ b/pkg/policies/security/security_test.go
@@ -141,21 +141,19 @@ func TestConfigPrecedence(t *testing.T) {
 
 func TestCheck(t *testing.T) {
 	tests := []struct {
-		Name              string
-		Org               OrgConfig
-		Repo              RepoConfig
-		SecEnabled        bool
-		cofigEnabled      bool
-		doNothingOnOptOut bool
-		Exp               policydef.Result
+		Name         string
+		Org          OrgConfig
+		Repo         RepoConfig
+		SecEnabled   bool
+		cofigEnabled bool
+		Exp          policydef.Result
 	}{
 		{
-			Name:              "NotEnabled",
-			Org:               OrgConfig{},
-			Repo:              RepoConfig{},
-			SecEnabled:        true,
-			cofigEnabled:      false,
-			doNothingOnOptOut: false,
+			Name:         "NotEnabled",
+			Org:          OrgConfig{},
+			Repo:         RepoConfig{},
+			SecEnabled:   true,
+			cofigEnabled: false,
 			Exp: policydef.Result{
 				Enabled:    false,
 				Pass:       true,
@@ -167,30 +165,15 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
-			Name:              "NotEnabledDoNothing",
-			Org:               OrgConfig{},
-			Repo:              RepoConfig{},
-			SecEnabled:        true,
-			cofigEnabled:      false,
-			doNothingOnOptOut: true,
-			Exp: policydef.Result{
-				Enabled:    false,
-				Pass:       true,
-				NotifyText: "Disabled",
-				Details:    details{},
-			},
-		},
-		{
 			Name: "Pass",
 			Org: OrgConfig{
 				OptConfig: config.OrgOptConfig{
 					OptOutStrategy: true,
 				},
 			},
-			Repo:              RepoConfig{},
-			SecEnabled:        true,
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			Repo:         RepoConfig{},
+			SecEnabled:   true,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       true,
@@ -208,10 +191,9 @@ func TestCheck(t *testing.T) {
 					OptOutStrategy: true,
 				},
 			},
-			Repo:              RepoConfig{},
-			SecEnabled:        false,
-			cofigEnabled:      true,
-			doNothingOnOptOut: false,
+			Repo:         RepoConfig{},
+			SecEnabled:   false,
+			cofigEnabled: true,
 			Exp: policydef.Result{
 				Enabled:    true,
 				Pass:       false,
@@ -254,7 +236,6 @@ func TestCheck(t *testing.T) {
 				c *github.Client, owner, repo string) (bool, error) {
 				return test.cofigEnabled, nil
 			}
-			doNothingOnOptOut = test.doNothingOnOptOut
 			res, err := check(context.Background(), nil, mockClient{}, "", "thisrepo")
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/pkg/policydef/policydef.go
+++ b/pkg/policydef/policydef.go
@@ -54,6 +54,9 @@ type Policy interface {
 	// Name must return the human readable name of the policy.
 	Name() string
 
+	// Check whether this policy is enabled or not
+	IsEnabled(ctx context.Context, c *github.Client, owner, repo string) (bool, error)
+
 	// Check checks whether the provided repo is in compliance with the policy or
 	// not. It must use the provided context and github client. See Result for
 	// more details on the return value.


### PR DESCRIPTION
The allstar run takes a very long time on a github org which has many repos that are excluded by virtue of being archived/forked etc, with these repos being excluded via "optOut" config. Instead this PR skips policy evaluation when the repositories are not enabled. 

@jeffmendoza If you feel the old behaviour should be preserved, let me know and I'll make it configurable. I can't imagine most use-cases would want policy evaluation on repos you are opting out.