### PR TITLE
Change scorecards link to refer to the top-level document

### DIFF
--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -188,7 +188,7 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 				notify = `Project is out of compliance with Security Scorecards policy
 
 **Rule Description**
-This is a generic passthrough policy that runs the configured checks from Security Scorecards. Please see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow) for more information on each check.
+This is a generic passthrough policy that runs the configured checks from Security Scorecards. Please see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md) for more information on each check.
 
 `
 			}


### PR DESCRIPTION
It's just a trivial issue. The link for a scorecards issue is directly to the dangerous workflows check, which is potentially a bit confusing if this isn't configured. It's better instead to link to the top-level documentation.