### PR TITLE
Always set ApprovalCount to 0 when RequireApproval is false

### DIFF
--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -49,6 +49,7 @@ type OrgConfig struct {
 	EnforceBranches map[string][]string `json:"enforceBranches"`
 
 	// RequireApproval : set to true to enforce approval on PRs, default true.
+	// When this config is false, ApprovalCount will always be set to 0.
 	RequireApproval bool `json:"requireApproval"`
 
 	// RequireCodeOwnerReviews : set to true to enforce code owner reviews on PRs, default false.
@@ -758,6 +759,11 @@ func mergeConfig(oc *OrgConfig, orc, rc *RepoConfig, repo string) *mergedConfig 
 	if !oc.OptConfig.DisableRepoOverride {
 		mc = mergeInRepoConfig(mc, rc, repo)
 	}
+
+	if !mc.RequireApproval {
+		mc.ApprovalCount = 0
+	}
+
 	return mc
 }
 


### PR DESCRIPTION
Fixes https://github.com/ossf/allstar/issues/419

This PR explicitly sets the `ApprovalCount` to 0 when `RequireApproval` is `false` because not requiring approval implies that zero approval count is needed.