### PR TITLE
Scorecards returning empty findings

### DIFF
--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -225,7 +225,11 @@ func listJoin(list []string) string {
 func convertLogs(logs []checker.CheckDetail) []string {
 	var s []string
 	for _, l := range logs {
-		s = append(s, fmt.Sprintf("%v[%v]:%v", l.Msg.Path, l.Msg.Offset, l.Msg.Text))
+		if l.Msg.Finding.Location == nil {
+			s = append(s, fmt.Sprintf("%v", l.Msg.Finding.Message))
+		} else {
+			s = append(s, fmt.Sprintf("%v[%v]:%v", l.Msg.Finding.Location.Value, *l.Msg.Finding.Location.LineStart, l.Msg.Finding.Message))
+		}
 	}
 	return s
 }


### PR DESCRIPTION
A fix for https://github.com/ossf/allstar/issues/422

With this commit https://github.com/ossf/scorecard/commit/2ea140a3ee9279904f29ed335b2bbef0923f242e, it seems the msg.X values aren't populated any more for token permissions. Instead we can get the information from l.Msg.Finding.

Tested it locally.