### PR TITLE
Add the scorecard score and threshold to GitHub issue

### DIFF
--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -189,8 +189,9 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 
 **Rule Description**
 This is a generic passthrough policy that runs the configured checks from Security Scorecards. Please see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md) for more information on each check.
-
+The score was %v, and the passing threshold is %v.
 `
+				notify = fmt.Sprintf(notify, res.Score, mc.Threshold)
 			}
 			if len(logs) > 10 {
 				notify += fmt.Sprintf(


### PR DESCRIPTION
This PR adds a line to a GitHub issue for scorecards that looks like:
```
The score was 8, and the passing threshold is 10.
```
This can be helpful to see how severe the finding is, or whether thresholds need to be adjusted etc.