### PR TITLE
Build chainguard/busybox based images for use with GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,19 @@ jobs:
       - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }} --image-refs allstar.ref
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
-
+      - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }}-busybox --image-refs allstar-busybox.ref
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
+          KO_DEFAULTBASEIMAGE: cgr.dev/chainguard/busybox
       - run: |
           echo "signing $(cat allstar.ref)"
           cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar.ref)"
+          echo "signing $(cat allstar-busybox.ref)"
+          cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar-busybox.ref)"
 
-      - run: gh release create ${{ github.ref_name }} --notes "ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}"
+      - run: |
+          gh release create ${{ github.ref_name }} --notes "Images:
+          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}
+          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}-busybox"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We would like the option of running AllStar as a GitHub Action. The current container image uses `cgr.dev/chainguard/static` which is an excellent minimal base with very little surface area. Unfortunately, GitHub Actions requires `tail` to be available for use as a container.

This change updates the build workflow to build a second image based on `cgr.dev/chainguard/busybox` with the tag `VERSION-busybox`. Combining this image with use of the `-once` flag makes it possible to run AllStar in GitHub Actions.

Example GitHub Actions jobs YAML:
~~~
name: "Scheduled AllStar Enforcement"
on:
  schedule:
  # Run on the hour
  - cron: "0 * * * *"

jobs:
  deployment:
    runs-on: ubuntu-latest
    container: ghcr.io/ossf/allstar:v3.1-busybox
    environment: prod
    steps:
      - name: "AllStar Enforce"
        env:
          APP_ID: ${{ vars.APP_ID }}
          KEY_SECRET: ${{ vars.KEY_SECRET }}
          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
        run: /ko-app/allstar -once
~~~

The above assumes a `prod` environment has been defined in GitHub Actions with `APP_ID` and `KEY_SECRET` defined as environment variables and `PRIVATE_KEY` as a secret. This prevents exposure of the `PRIVATE_KEY` to jobs not run against `prod`.

The standard minimal `cgr.dev/chainguard/stable` images will continue to be built and should be used where possible due to their reduced attack surface area.