### PR TITLE
[BugFix] Scorecard Evaluation Crash

### DIFF
--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -226,10 +226,14 @@ func listJoin(list []string) string {
 func convertLogs(logs []checker.CheckDetail) []string {
 	var s []string
 	for _, l := range logs {
-		if l.Msg.Finding.Location == nil {
-			s = append(s, fmt.Sprintf("%v", l.Msg.Finding.Message))
+		if l.Msg.Finding != nil {
+			if l.Msg.Finding.Location == nil {
+				s = append(s, fmt.Sprintf("%v", l.Msg.Finding.Message))
+			} else {
+				s = append(s, fmt.Sprintf("%v[%v]:%v", l.Msg.Finding.Location.Value, *l.Msg.Finding.Location.LineStart, l.Msg.Finding.Message))
+			}
 		} else {
-			s = append(s, fmt.Sprintf("%v[%v]:%v", l.Msg.Finding.Location.Value, *l.Msg.Finding.Location.LineStart, l.Msg.Finding.Message))
+			s = append(s, fmt.Sprintf("%v[%v]:%v", l.Msg.Path, l.Msg.Offset, l.Msg.Text))
 		}
 	}
 	return s


### PR DESCRIPTION
## Description
The Allstar Scorecard checks for Branch Protection (and others) commonly fail due to the `l.Msg.Finding` variable being nil. This causes the application to crash when it attempts to find `l.Msg.Finding.Location` to perform the nil check.

This PR aims to address this issue by handling cases where `l.Msg.Finding` is nil using the legacy logic prior to https://github.com/ossf/allstar/pull/424. Whilst still incorporating the more modern handling provided by that change which is required for check such as the Token-Permissions check.