### PR TITLE
Skip empty repositories for Allstar policy enforcement

### DIFF
--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -334,9 +334,10 @@ func isRepositoryEmptyReal(ctx context.Context, c *github.Client, owner, repo, p
 			Str("repo", repo).
 			Str("area", policy).
 			Msg("Repository is empty, skipping")
+		return true, nil
 	}
 
-	return true, nil
+	return false, nil
 }
 
 // runPoliciesReal enforces policies on the provided repo. It is meant to be called

--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -323,11 +323,12 @@ func EnforceJob(ctx context.Context, ghc *ghclients.GHClients, d time.Duration, 
 
 // returns true if the repository has content and false if it's empty
 func isRepositoryEmptyReal(ctx context.Context, c *github.Client, owner, repo, policy string) (bool, error) {
-	_, resp, err := c.Repositories.ListContributorsStats(ctx, owner, repo)
-	if err != nil {
+	opts := github.RepositoryContentGetOptions{}
+	file, dirs, resp, err := c.Repositories.GetContents(ctx, owner, repo, "", &opts)
+	if err != nil && resp.StatusCode != http.StatusNotFound {
 		return false, err
 	}
-	if resp.StatusCode == http.StatusNoContent {
+	if file == nil && len(dirs) == 0 {
 		log.Info().
 			Str("org", owner).
 			Str("repo", repo).

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -91,6 +91,42 @@ func (m MockGhClients) Get(i int64) (*github.Client, error) {
 
 func (m MockGhClients) LogCacheSize() {}
 
+func TestSkipEmptyRepositories(t *testing.T) {
+	policiesGetPolicies = func() []policydef.Policy {
+		return []policydef.Policy{
+			pol{},
+		}
+	}
+
+	isRepositoryEmpty = func(ctx context.Context, c *github.Client, s1, s2, s3 string) (bool, error) {
+		return true, nil
+	}
+
+	repo := "fake-repo"
+
+	tests := []struct {
+		Desc string
+	}{
+		{
+			Desc: "test skip a single empty repository",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			enforceResults, err := runPoliciesReal(context.Background(), nil, "", repo, true, "")
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if len(enforceResults) != 0 {
+				t.Errorf("expected no policy results, got %+v\n", enforceResults)
+			}
+		})
+	}
+}
+
 func TestRunPolicies(t *testing.T) {
 	policiesGetPolicies = func() []policydef.Policy {
 		return []policydef.Policy{
@@ -106,6 +142,9 @@ func TestRunPolicies(t *testing.T) {
 	issueClose = func(ctx context.Context, c *github.Client, owner, repo, policy string) error {
 		closeCalled = true
 		return nil
+	}
+	isRepositoryEmpty = func(ctx context.Context, c *github.Client, s1, s2, s3 string) (bool, error) {
+		return false, nil
 	}
 	repo := "fake-repo"
 	tests := []struct {


### PR DESCRIPTION
Skip empty repositories for Allstar policy enforcement. Check whether they're empty using [GitHub REST API](https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#get-all-contributor-commit-activity).