### PR TITLE
Bug: Update memorycache for tarballs

### DIFF
--- a/pkg/ghclients/memorycache.go
+++ b/pkg/ghclients/memorycache.go
@@ -53,10 +53,12 @@ func (c *memoryCache) Get(key string) (resp []byte, ok bool) {
 
 // Set saves response resp to the cache with key
 func (c *memoryCache) Set(key string, resp []byte) {
-	if strings.Contains(key, ".tar.gz") {
+	if strings.Contains(key, ".tar.gz") || strings.Contains(key, "tarball/") {
 		// Don't cache tarballs.  Currently GitHub redirects tarball downloads to a
 		// URL that looks like this:
 		// "https://codeload.github.com/<owner>/<repo>/legacy.tar.gz/refs/heads/main"
+		// Scorecard requests tarballs that look like:
+		// "https://api.github.com/repos/<owner>/<repo>/tarball/"
 		// Hopefully this continues to have ".tar.gz" in it.
 		return
 	}


### PR DESCRIPTION
Update condition to not cache tarballs. Scorecard requests tarball with `api.github.com` URLs that end with `tarball/` (See [tarball.go](https://github.com/ossf/scorecard/blob/92470deac34ef9eaaa2707e13b7d800088e0898c/clients/githubrepo/tarball.go#L122)). 

Although those URLs 302 redirect to `codeload.github.com` URLs as the comment says, the `api.github.com` URL is what the `HttpClient` sees.

Addresses #381.