### PR TITLE
Change locking for Scorecard interface

### DIFF
--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -71,18 +71,13 @@ func Get(ctx context.Context, fullRepo string, tr http.RoundTripper) (*ScClient,
 // Function Close will close the scorecard clients. This cleans up the
 // downloaded tarball.
 func Close(fullRepo string) {
-	mMutex.RLock()
-	if scClients == nil {
-		mMutex.RUnlock()
-		return
-	}
+	mMutex.Lock()
 	scc, ok := scClients[fullRepo]
-	mMutex.RUnlock()
 	if !ok {
+		mMutex.Unlock()
 		return
 	}
 	scc.ScRepoClient.Close()
-	mMutex.Lock()
 	delete(scClients, fullRepo)
 	mMutex.Unlock()
 }

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -36,7 +36,7 @@ type ScClient struct {
 	ScRepoClient clients.RepoClient
 }
 
-var scClients map[string]*ScClient
+var scClients map[string]*ScClient = make(map[string]*ScClient)
 var mMutex sync.RWMutex
 
 const defaultGitRef = "HEAD"
@@ -53,15 +53,6 @@ func init() {
 // exist. The github repo is initialized, which means the tarball is
 // downloaded.
 func Get(ctx context.Context, fullRepo string, tr http.RoundTripper) (*ScClient, error) {
-	mMutex.RLock()
-	if scClients == nil {
-		mMutex.RUnlock()
-		mMutex.Lock()
-		scClients = make(map[string]*ScClient)
-		mMutex.Unlock()
-	} else {
-		mMutex.RUnlock()
-	}
 	mMutex.Lock()
 	if scc, ok := scClients[fullRepo]; ok {
 		mMutex.Unlock()

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -62,17 +62,16 @@ func Get(ctx context.Context, fullRepo string, tr http.RoundTripper) (*ScClient,
 	} else {
 		mMutex.RUnlock()
 	}
-	mMutex.RLock()
+	mMutex.Lock()
 	if scc, ok := scClients[fullRepo]; ok {
-		mMutex.RUnlock()
+		mMutex.Unlock()
 		return scc, nil
 	}
-	mMutex.RUnlock()
 	scc, err := create(ctx, fullRepo, tr)
 	if err != nil {
+		mMutex.Unlock()
 		return nil, err
 	}
-	mMutex.Lock()
 	scClients[fullRepo] = scc
 	mMutex.Unlock()
 	return scc, nil


### PR DESCRIPTION
This PR makes the following changes:
1. Initializes `scClients` once globally
2. In `Scorecard.Get`, use `Lock()/Unlock()` for reading from the `scClients` map. This prevents two threads from independently reading the value, both deciding that there's no `scClient` for their repo, and independently (but not concurrently) creating clients. Although they don't concurrently modify the map, thread 2 will overwrite the `scClient` created by thread 1.
3. In `Scorecard.Close`, use `Lock()/Unlock()` instead of the R-variants. This prevents the case where two threads `Close()` both reach the `if !ok` line with `ok == true`, and then independently (but not concurrently) attempting `ScRepoClient.Close` and `delete`.

This should reduce overall repeated work by making the critical sections larger.