### PR TITLE
Don't create issues for dangerous workflows when we have an inconclus…

### DIFF
--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -136,7 +136,7 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 	}
 
 	logs := convertLogs(l.Flush())
-	pass := res.Score >= checker.MaxResultScore
+	pass := res.Score >= checker.MaxResultScore || res.Score == checker.InconclusiveResultScore
 	var notify string
 	if !pass {
 		notify = fmt.Sprintf(`Project is out of compliance with Dangerous Workflow policy: %v


### PR DESCRIPTION
…ive result

Since the recent update we are getting a ton of issues created for dangerous workflows, when the repo in question don't contain any github action workflows. The PR changes the check to pass if we have an inconclusive result (no workflows found)