### PR TITLE
Correct references to OpenSSF Scorecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ here](https://pkg.go.dev/github.com/ossf/allstar/pkg/policies/workflow#OrgConfig
 
 This policy checks the GitHub Actions workflow configuration files
 (`.github/workflows`), for any patterns that match known dangerous
-behavior. See the [Security Scorecards
-Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow)
+behavior. See the [OpenSSF Scorecard
+documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow)
 for more information on this check.
 
 ### Generic Scorecard Check
@@ -333,8 +333,8 @@ here](https://pkg.go.dev/github.com/ossf/allstar/pkg/policies/scorecard#OrgConfi
 
 This policy runs any scorecard check listed in the `checks` configuration. All
 checks run must have a score equal or above the `threshold` setting. Please see
-the [Security Scorecards
-Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
+the [OpenSSF Scorecard
+documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
 for more information on each check.
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ossf/allstar/badge)](https://api.securityscorecards.dev/projects/github.com/ossf/allstar)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ossf/allstar/badge)](https://api.scorecard.dev/projects/github.com/ossf/allstar)
 
 <img align="right" src="artwork/openssf_allstar_alt.png" width="300" height="400">
 

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -159,7 +159,7 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 		notify = fmt.Sprintf(`Project is out of compliance with Binary Artifacts policy: %v
 
 **Rule Description**
-Binary Artifacts are an increased security risk in your repository. Binary artifacts cannot be reviewed, allowing the introduction of possibly obsolete or maliciously subverted executables. For more information see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts) for Binary Artifacts.
+Binary artifacts are an increased security risk in your repository. Binary artifacts cannot be reviewed, allowing the introduction of possibly obsolete or maliciously subverted executables. For more information, see the [OpenSSF Scorecard documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts) on binary artifacts.
 
 **Remediation Steps**
 To remediate, remove the generated executable artifacts from the repository.
@@ -169,13 +169,13 @@ To remediate, remove the generated executable artifacts from the repository.
 		if len(logs) > 10 {
 			notify += fmt.Sprintf(
 				"**First 10 Artifacts Found**\n\n%v"+
-					"- Run a Scorecards scan to see full list.\n\n",
+					"- Run a Scorecard scan to see full list.\n\n",
 				listJoin(logs[:10]))
 		} else {
 			notify += fmt.Sprintf("**Artifacts Found**\n\n%v\n", listJoin(logs))
 		}
 		notify += `**Additional Information**
-This policy is drawn from [Security Scorecards](https://github.com/ossf/scorecard/), which is a tool that scores a project's adherence to security best practices. You may wish to run a Scorecards scan directly on this repository for more details.`
+This policy uses [OpenSSF Scorecard](https://github.com/ossf/scorecard/). You may wish to run a Scorecard scan directly on this repository for more details.`
 	}
 
 	return &policydef.Result{

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package scorecard implements the generic Security Scorecards policy
+// Package scorecard implements the generic OpenSSF Scorecard policy
 package scorecard
 
 import (
@@ -31,7 +31,7 @@ import (
 )
 
 const configFile = "scorecard.yaml"
-const polName = "Security Scorecards"
+const polName = "OpenSSF Scorecard"
 
 // OrgConfig is the org-level config definition for this policy.
 type OrgConfig struct {
@@ -42,11 +42,12 @@ type OrgConfig struct {
 	// Action defines which action to take, default log, other: issue...
 	Action string `json:"action"`
 
-	// Checks is a list of check names to run from Security Scorecards. These
-	// must match the name that the check uses in it's call to
-	// "registerCheck". See the check code for each name:
-	// https://github.com/ossf/scorecard/tree/main/checks For example, the name
-	// for the Signed Releases check is "Signed-Releases".
+	// Checks is a list of check names to run from OpenSSF Scorecard. These
+	// must match the name that the check uses in its call to "registerCheck".
+	// For example, the name for the Signed Releases check is "Signed-Releases".
+	//
+	// See the checks code for each name:
+	// https://github.com/ossf/scorecard/tree/main/checks
 	Checks []string `json:"checks"`
 
 	// Threshold is the score threshold that checks must meet to pass the
@@ -196,10 +197,10 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 		if res.Score < mc.Threshold && res.Score != checker.InconclusiveResultScore {
 			pass = false
 			if notify == "" {
-				notify = `Project is out of compliance with Security Scorecards policy
+				notify = `Project is out of compliance with OpenSSF Scorecard policy.
 
 **Rule Description**
-This is a generic passthrough policy that runs the configured checks from Security Scorecards. Please see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md) for more information on each check.
+This is a generic passthrough policy that runs the configured checks from OpenSSF Scorecard. Please see the [OpenSSF Scorecard documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md) for more information on each check.
 The score was %v, and the passing threshold is %v.
 `
 				notify = fmt.Sprintf(notify, res.Score, mc.Threshold)
@@ -207,7 +208,7 @@ The score was %v, and the passing threshold is %v.
 			if len(logs) > 10 {
 				notify += fmt.Sprintf(
 					"**First 10 Results from policy: %v : %v**\n\n%v"+
-						"- Run a Scorecards scan to see full list.\n\n",
+						"- Run a Scorecard scan to see full list.\n\n",
 					res.Name, res.Reason, listJoin(logs[:10]))
 			} else {
 				notify += fmt.Sprintf("**Results from policy: %v : %v**\n\n%v\n",

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -142,24 +142,22 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 		notify = fmt.Sprintf(`Project is out of compliance with Dangerous Workflow policy: %v
 
 **Rule Description**
-Dangerous Workflows are GitHub Action workflows that exhibit dangerous patterns that could render them vulnerable to attack. A vulnerable workflow is susceptible to leaking repository secrets, or allowing an attacker write access using the GITHUB_TOKEN. For more information about the particular patterns that are detected see the [Security Scorecards Documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow) for Dangerous Workflow.
+Dangerous workflows are GitHub Action workflows that exhibit dangerous patterns that could render them vulnerable to attack. A vulnerable workflow is susceptible to leaking repository secrets, or allowing an attacker write access using the GITHUB_TOKEN. For more information about the particular patterns that are detected, see the [OpenSSF Scorecard documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow) on dangerous workflows.
 
 **Remediation Steps**
 Avoid the dangerous workflow patterns. See this [post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for information on avoiding untrusted code checkouts. See this [document](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) for information on avoiding and mitigating the risk of script injections.
-
-
 `,
 			res.Reason)
 		if len(logs) > 10 {
 			notify += fmt.Sprintf(
 				"**First 10 Dangerous Patterns Found**\n\n%v"+
-					"- Run a Scorecards scan to see full list.\n\n",
+					"- Run a Scorecard scan to see full list.\n\n",
 				listJoin(logs[:10]))
 		} else {
 			notify += fmt.Sprintf("**Dangerous Patterns Found**\n\n%v\n", listJoin(logs))
 		}
 		notify += `**Additional Information**
-This policy is drawn from [Security Scorecards](https://github.com/ossf/scorecard/), which is a tool that scores a project's adherence to security best practices. You may wish to run a Scorecards scan directly on this repository for more details.`
+This policy uses [OpenSSF Scorecard](https://github.com/ossf/scorecard/). You may wish to run a Scorecard scan directly on this repository for more details.`
 	}
 
 	return &policydef.Result{


### PR DESCRIPTION
Partially addresses https://github.com/ossf/allstar/issues/535
(it may fully address the issue, but for now, I'd like to leave that one open for additional investigation)

- docs: Correct instances of "Security Scorecards" to "OpenSSF Scorecard"

  Includes minor fixes to surrounding documentation.

- README: Correct Scorecard API URL