### PR TITLE
Looping container image signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,14 @@ jobs:
           KO_DEFAULTBASEIMAGE: cgr.dev/chainguard/busybox
           KO_DEFAULTPLATFORMS: linux/arm64,linux/amd64
       - run: |
-          echo "signing $(cat allstar.ref)"
-          cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar.ref)"
-          echo "signing $(cat allstar-busybox.ref)"
-          cosign sign --yes -a git_sha="$GITHUB_SHA" "$(cat allstar-busybox.ref)"
+          while read ref; do
+            echo "signing $ref"
+            cosign sign --yes -a git_sha="$GITHUB_SHA" "$ref"
+          done < allstar.ref
+          while read ref; do
+            echo "signing $ref"
+            cosign sign --yes -a git_sha="$GITHUB_SHA" "$ref"
+          done < allstar-busybox.ref
 
       - run: |
           gh release create ${{ github.ref_name }} --notes "Images:


### PR DESCRIPTION
Fix for signing-issue introduced by fix https://github.com/ossf/allstar/pull/615 from ticket https://github.com/ossf/allstar/issues/614 when the ref-file became multi-line.

As I do not have code signing configured I can not test this directly. But I've tested the loop syntax.
