### PR TITLE
Update workflow policy to scan all branches for dangerous workflows #569

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ This policy's config file is named `dangerous_workflow.yaml`, and the [config
 definitions are
 here](https://pkg.go.dev/github.com/ossf/allstar/pkg/policies/workflow#OrgConfig).
 
+This policy will run against **all** branches, see rationale [here](https://github.com/ossf/allstar/issues/569).
+
 This policy checks the GitHub Actions workflow configuration files
 (`.github/workflows`), for any patterns that match known dangerous
 behavior. See the [OpenSSF Scorecard

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -120,7 +120,7 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
-	scc, err := scorecard.Get(ctx, fullName, tr)
+	scc, err := scorecard.Get(ctx, fullName, false, tr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -121,6 +121,7 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecard.Get(ctx, fullName, false, tr)
+	defer scorecard.Close(fullName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/binary/binary.go
+++ b/pkg/policies/binary/binary.go
@@ -121,7 +121,6 @@ func (b Binary) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecard.Get(ctx, fullName, false, tr)
-	defer scorecard.Close(fullName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -88,6 +88,7 @@ type details struct {
 var configFetchConfig func(context.Context, *github.Client, string, string, string, config.ConfigLevel, interface{}) error
 var configIsEnabled func(context.Context, config.OrgOptConfig, config.RepoOptConfig, config.RepoOptConfig, *github.Client, string, string) (bool, error)
 var scorecardGet func(context.Context, string, bool, http.RoundTripper) (*scorecard.ScClient, error)
+var scorecardClose func(string) ()
 var checksAllChecks checker.CheckNameToFnMap
 var scRun func(context.Context, clients.Repo, ...sc.Option) (sc.Result, error)
 
@@ -96,6 +97,7 @@ func init() {
 	configIsEnabled = config.IsEnabled
 	checksAllChecks = checks.GetAll()
 	scorecardGet = scorecard.Get
+	scorecardClose = scorecard.Close
 	scRun = sc.Run
 }
 
@@ -142,6 +144,7 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecardGet(ctx, fullName, false, tr)
+	defer scorecardClose(fullName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -88,7 +88,6 @@ type details struct {
 var configFetchConfig func(context.Context, *github.Client, string, string, string, config.ConfigLevel, interface{}) error
 var configIsEnabled func(context.Context, config.OrgOptConfig, config.RepoOptConfig, config.RepoOptConfig, *github.Client, string, string) (bool, error)
 var scorecardGet func(context.Context, string, bool, http.RoundTripper) (*scorecard.ScClient, error)
-var scorecardClose func(string) ()
 var checksAllChecks checker.CheckNameToFnMap
 var scRun func(context.Context, clients.Repo, ...sc.Option) (sc.Result, error)
 
@@ -97,7 +96,6 @@ func init() {
 	configIsEnabled = config.IsEnabled
 	checksAllChecks = checks.GetAll()
 	scorecardGet = scorecard.Get
-	scorecardClose = scorecard.Close
 	scRun = sc.Run
 }
 
@@ -144,7 +142,6 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecardGet(ctx, fullName, false, tr)
-	defer scorecardClose(fullName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -87,7 +87,7 @@ type details struct {
 
 var configFetchConfig func(context.Context, *github.Client, string, string, string, config.ConfigLevel, interface{}) error
 var configIsEnabled func(context.Context, config.OrgOptConfig, config.RepoOptConfig, config.RepoOptConfig, *github.Client, string, string) (bool, error)
-var scorecardGet func(context.Context, string, http.RoundTripper) (*scorecard.ScClient, error)
+var scorecardGet func(context.Context, string, bool, http.RoundTripper) (*scorecard.ScClient, error)
 var checksAllChecks checker.CheckNameToFnMap
 var scRun func(context.Context, clients.Repo, ...sc.Option) (sc.Result, error)
 
@@ -141,7 +141,7 @@ func (b Scorecard) Check(ctx context.Context, c *github.Client, owner,
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
-	scc, err := scorecardGet(ctx, fullName, tr)
+	scc, err := scorecardGet(ctx, fullName, false, tr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/scorecard/scorecard_test.go
+++ b/pkg/policies/scorecard/scorecard_test.go
@@ -193,7 +193,7 @@ func TestCheck(t *testing.T) {
 				error) {
 				return true, nil
 			}
-			scorecardGet = func(ctx context.Context, fullRepo string,
+			scorecardGet = func(ctx context.Context, fullRepo string, local bool,
 				tr http.RoundTripper) (*scorecard.ScClient, error) {
 				return &scorecard.ScClient{}, nil
 			}

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -107,7 +107,6 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecard.Get(ctx, fullName, true, tr)
-	defer scorecard.Close(fullName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -107,6 +107,7 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
 	tr := c.Client().Transport
 	scc, err := scorecard.Get(ctx, fullName, true, tr)
+	defer scorecard.Close(fullName)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +140,7 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 				Msg(msg)
 			return &policydef.Result{
 				Enabled:    enabled,
-				Pass:       true,
+				Pass:       false,
 				NotifyText: fmt.Sprintf("%s: %v", msg, err),
 				Details:    details{},
 			}, nil
@@ -154,7 +155,7 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 				Msg(msg)
 			return &policydef.Result{
 				Enabled:    enabled,
-				Pass:       true,
+				Pass:       false,
 				NotifyText: msg,
 				Details:    details{},
 			}, nil
@@ -171,7 +172,7 @@ func (b Workflow) Check(ctx context.Context, c *github.Client, owner,
 				Msg(msg)
 			return &policydef.Result{
 				Enabled:    enabled,
-				Pass:       true,
+				Pass:       false,
 				NotifyText: fmt.Sprintf("%s: %v", msg, res.Error),
 				Details:    details{},
 			}, nil

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -115,12 +115,15 @@ func (scc ScClient) FetchBranches() ([]string, error) {
 	}
 
 	var ret []string
-	refs.ForEach(func(ref *plumbing.Reference) error {
+	err = refs.ForEach(func(ref *plumbing.Reference) error {
 		if ref.Name().IsRemote() {
 			ret = append(ret, ref.Name().String())
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 	return ret, nil
 }
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -4,7 +4,7 @@ Major features and changes added to Allstar.
 
 ## Added since last release
 
--
+- Dangerous Workflow policy will now be run for all branches. [Link](https://github.com/ossf/allstar/issues/569)
 
 ## Release v3.0
 


### PR DESCRIPTION
This PR addresses https://github.com/ossf/allstar/issues/569 and introduces 2 changes:
 - Adds support for local git repos in scorecard.go, with additional functionality to switch between all branches. I opted to not replace the existing Github client as policies may want to interact directly with Github.
 - Updates workflow.go to scan all remote branches in the local git repo.

Tested locally using https://github.com/serb-google/allstar, with a branch `insecure_test` which contains a fake unsafe workflow rule. Verified this triggered the alert which included output `Vulnerable Branch: refs/remotes/origin/insecure_test`.

 This is my first contribution to this repo, please review carefully :)