### PR TITLE
Add auth workflow to clone private repos

### DIFF
--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -201,6 +201,9 @@ func _createLocal(ctx context.Context, fullRepo string) (*ScClient, error) {
 		return nil, err
 	}
 	client, err := ghc.Get(0)
+	if err != nil {
+		return nil, err
+	}
 
 	log.Debug().
 		Str("owner", owner).

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -24,10 +24,14 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	plumbinghttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/go-github/v59/github"
+	"github.com/ossf/allstar/pkg/ghclients"
 	"github.com/ossf/scorecard/v5/clients"
 	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	"github.com/ossf/scorecard/v5/clients/localdir"
@@ -51,10 +55,12 @@ const defaultGitRef = "HEAD"
 
 var githubrepoMakeGitHubRepo func(string) (clients.Repo, error)
 var githubrepoCreateGitHubRepoClientWithTransport func(context.Context, http.RoundTripper) clients.RepoClient
+var createLocal func(context.Context, string) (*ScClient, error)
 
 func init() {
 	githubrepoMakeGitHubRepo = githubrepo.MakeGithubRepo
 	githubrepoCreateGitHubRepoClientWithTransport = githubrepo.CreateGithubRepoClientWithTransport
+	createLocal = _createLocal
 }
 
 // Function Get will get the scorecard clients and create them if they don't
@@ -92,7 +98,7 @@ func Get(ctx context.Context, fullRepo string, local bool, tr http.RoundTripper)
 
 // Switch the local repo between branches
 func (scc ScClient) SwitchLocalBranch(branchName string) error {
-	log.Info().
+	log.Debug().
 		Str("branch", branchName).
 		Msg("Branch checkout")
 
@@ -129,8 +135,8 @@ func (scc ScClient) FetchBranches() ([]string, error) {
 
 // Checkout a repo into a local directory
 // returns the path to the local repo and a git repo reference
-func checkoutRepo(fullRepo string) (string, *git.Repository, error) {
-	log.Info().
+func checkoutRepo(fullRepo string, token string) (string, *git.Repository, error) {
+	log.Debug().
 		Str("repo", fullRepo).
 		Msg("Repo checkout")
 	// create a temp dir to store the repo
@@ -139,9 +145,19 @@ func checkoutRepo(fullRepo string) (string, *git.Repository, error) {
 		return "", nil, err
 	}
 
+	// can be empty for testing
+	var auth *plumbinghttp.BasicAuth
+	if token != "" {
+		auth = &plumbinghttp.BasicAuth{
+			Username: "x-access-token", // can be any value
+			Password: token,
+		}
+	}
+
 	// checkout to the temp dir
 	repo, err := git.PlainClone(dir, false, &git.CloneOptions{
-		URL: "https://github.com/" + fullRepo,
+		URL:  "https://github.com/" + fullRepo,
+		Auth: auth,
 	})
 	if err != nil {
 		return "", nil, err
@@ -169,16 +185,62 @@ func Close(fullRepo string) {
 	}
 }
 
-func createLocal(ctx context.Context, fullRepo string) (*ScClient, error) {
-	localPath, gitRepo, err := checkoutRepo(fullRepo)
+// As we are potentially running against a private GitHub repo, we need to use a two step process
+// to checkout a local copy of the full repo:
+// 1) Use our go-github API access to create a scoped installation access token
+// 2) Use the access token to clone the repo with go-git
+// ref: https://github.com/orgs/community/discussions/24575#discussioncomment-8076322
+func _createLocal(ctx context.Context, fullRepo string) (*ScClient, error) {
+	fullRepoSplit := strings.Split(fullRepo, "/")
+	owner := strings.ToLower(fullRepoSplit[0])
+	repo := strings.ToLower(fullRepoSplit[1])
+
+	// connect to the GitHub API
+	ghc, err := ghclients.NewGHClients(ctx, http.DefaultTransport)
 	if err != nil {
 		return nil, err
 	}
+	client, err := ghc.Get(0)
 
+	log.Debug().
+		Str("owner", owner).
+		Str("repo", repo).
+		Str("fullRepo", fullRepo).
+		Msg("local checkout")
+
+	// use the GitHub API to issue an installation access token
+	installation, _, err := client.Apps.FindRepositoryInstallation(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().
+		Int64("ID", installation.GetID()).
+		Msg("local checkout -- found installation ID")
+	opts := &github.InstallationTokenOptions{
+		Repositories: []string{repo},
+		Permissions: &github.InstallationPermissions{
+			Contents: github.String("read"),
+		},
+	}
+	token, _, err := client.Apps.CreateInstallationToken(ctx, installation.GetID(), opts)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().
+		Msg("local checkout -- installation access token retrieved")
+
+	// use the installation access token
+	localPath, gitRepo, err := checkoutRepo(fullRepo, token.GetToken())
+	if err != nil {
+		return nil, err
+	}
 	scr, err := localdir.MakeLocalDirRepo(localPath)
 	if err != nil {
 		return nil, err
 	}
+	log.Debug().
+		Msg("local checkout -- checkout success")
+
 	return &ScClient{
 		ScRepo:    scr,
 		localPath: localPath,

--- a/pkg/scorecard/scorecard_test.go
+++ b/pkg/scorecard/scorecard_test.go
@@ -22,6 +22,7 @@ import (
 	time "time"
 
 	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/localdir"
 )
 
 var initRepo func(clients.Repo, string, int) error
@@ -250,7 +251,28 @@ func TestRecreate(t *testing.T) {
 	Close("org/repo")
 }
 
+// as we cannot interact with the GitHub API, this is a simple version of createLocal
+// which just fetches a public repo for local testing
+func _testCreateLocal(ctx context.Context, fullRepo string) (*ScClient, error) {
+	localPath, gitRepo, err := checkoutRepo(fullRepo, "")
+	if err != nil {
+		return nil, err
+	}
+
+	scr, err := localdir.MakeLocalDirRepo(localPath)
+	if err != nil {
+		return nil, err
+	}
+	return &ScClient{
+		ScRepo:    scr,
+		localPath: localPath,
+		gitRepo:   gitRepo,
+	}, nil
+}
+
+
 func TestLocal(t *testing.T) {
+	createLocal = _testCreateLocal
 	repo := "go-git/go-git"
 	scc, err := Get(context.Background(), repo, true, nil)
 	if err != nil {


### PR DESCRIPTION
Addresses comment https://github.com/ossf/allstar/pull/622#issuecomment-2702979862 from @coheigea. 

I was able to validate this works as expected against a test private repo with an "unsafe" workflow. JSON log line:
```
{
  "severity": "INFO",
  "org": "serb-google",
  "repo": "test_private",
  "area": "Dangerous Workflow",
  "result": false,
  "enabled": false,
  "notify": "Project is out of compliance with Dangerous Workflow policy: dangerous workflow patterns detected\n\n\t\t**Rule Description**\n\t\tDangerous workflows are GitHub Action workflows that exhibit dangerous patterns that could render them vulnerable to attack. A vulnerable workflow is susceptible to leaking repository secrets, or allowing an attacker write access using the GITHUB_TOKEN. For more information about the particular patterns that are detected, see the [OpenSSF Scorecard documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#dangerous-workflow) on dangerous workflows. Any vulnerable branch can be exploited, so this rule will check all branches (vulnerable list below).\n\n\t\t**Remediation Steps**\n\t\tAvoid the dangerous workflow patterns. See this [post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for information on avoiding untrusted code checkouts. See this [document](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) for information on avoiding and mitigating the risk of script injections.\n\t\t**Dangerous Patterns Found**\n\n- [0]:\n\n**Additional Information**\n\tThis policy uses [OpenSSF Scorecard](https://github.com/ossf/scorecard/). You may wish to run a Scorecard scan directly on this repository for more details.\n\nVulnerable Branch: refs/remotes/origin/insecuretest2",
  "details": {
    "Findings": null
  },
  "time": "2025-03-07T20:37:01Z",
  "message": "Policy run result."
}
```