### PR TITLE
dependabot: Enable grouped updates and set update interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: gomod
+- package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: daily
+    interval: "weekly"
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,27 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-  open-pull-requests-limit: 10
+  groups:
+    gomod:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "golang.org/x/*"
+    golang-x:
+      patterns:
+        - "golang.org/x/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "actions/*"
+        - "github/*"
+    github-owned:
+      patterns:
+        - "actions/*"
+        - "github/*"


### PR DESCRIPTION
Given this has been working in other OpenSSF Scorecard repos (https://github.com/ossf/scorecard/pull/4444, https://github.com/ossf/scorecard-action/pull/1276, https://github.com/ossf/scorecard-webapp/pull/618) for a while now, let's enable grouped updates here.

cc: @jeffmendoza 