### PR TITLE
Add config option to specify branches for dangerous workflow

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,11 @@ type OrgConfig struct {
 
 	// Schedule specifies whether to perform certain actions on specific days.
 	Schedule *ScheduleConfig `json:"schedule"`
+
+	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Blank/default to scan all branches.
+	// Must use format "refs/remotes/origin/branch_name".
+	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
 }
 
 // OrgOptConfig is used in Allstar and policy-specific org-level config to
@@ -108,6 +113,11 @@ type RepoConfig struct {
 
 	// Schedule specifies days during which to not send notifications,
 	Schedule *ScheduleConfig `json:"schedule"`
+
+	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Blank/default to scan all branches.
+	// Must use format "refs/remotes/origin/branch_name".
+	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
 }
 
 // RepoOptConfig is used in Allstar and policy-specific repo-level config to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,7 +66,7 @@ type OrgConfig struct {
 	// Schedule specifies whether to perform certain actions on specific days.
 	Schedule *ScheduleConfig `json:"schedule"`
 
-	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Comma-separated branch list to scan for Dangerous Workflows.
 	// Blank/default to scan all branches.
 	// Must use format "refs/remotes/origin/branch_name".
 	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
@@ -114,7 +114,7 @@ type RepoConfig struct {
 	// Schedule specifies days during which to not send notifications,
 	Schedule *ScheduleConfig `json:"schedule"`
 
-	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Comma-separated branch list to scan for Dangerous Workflows.
 	// Blank/default to scan all branches.
 	// Must use format "refs/remotes/origin/branch_name".
 	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,11 +65,6 @@ type OrgConfig struct {
 
 	// Schedule specifies whether to perform certain actions on specific days.
 	Schedule *ScheduleConfig `json:"schedule"`
-
-	// Comma-separated branch list to scan for Dangerous Workflows.
-	// Blank/default to scan all branches.
-	// Must use format "refs/remotes/origin/branch_name".
-	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
 }
 
 // OrgOptConfig is used in Allstar and policy-specific org-level config to
@@ -113,11 +108,6 @@ type RepoConfig struct {
 
 	// Schedule specifies days during which to not send notifications,
 	Schedule *ScheduleConfig `json:"schedule"`
-
-	// Comma-separated branch list to scan for Dangerous Workflows.
-	// Blank/default to scan all branches.
-	// Must use format "refs/remotes/origin/branch_name".
-	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
 }
 
 // RepoOptConfig is used in Allstar and policy-specific repo-level config to

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -44,7 +44,7 @@ type OrgConfig struct {
 	// Action defines which action to take, default log, other: issue...
 	Action string `json:"action"`
 
-	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Comma-separated branch list to scan for Dangerous Workflows.
 	// Blank/default to scan all branches.
 	// Must use format "refs/remotes/origin/branch_name".
 	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`
@@ -58,7 +58,7 @@ type RepoConfig struct {
 	// Action overrides the same setting in org-level, only if present.
 	Action *string `json:"action"`
 
-	// Comma-seperated branch list to scan for Dangerous Workflows.
+	// Comma-separated branch list to scan for Dangerous Workflows.
 	// Blank/default to scan all branches.
 	// Must use format "refs/remotes/origin/branch_name".
 	DangerousWorkflowBranchList string `json:"dangerousWorkflowBranchList"`

--- a/pkg/policies/workflow/workflow.go
+++ b/pkg/policies/workflow/workflow.go
@@ -44,9 +44,9 @@ type OrgConfig struct {
 	// Action defines which action to take, default log, other: issue...
 	Action string `json:"action"`
 
-	// Comma-separated branch list to scan for Dangerous Workflows.
-	// Blank to scan all branches. The string "default" will be replaced with the git default branch.
-	// Must use format "refs/remotes/origin/branch_name".
+	// Comma-separated branch list to scan for Dangerous Workflows.  Blank to
+	// scan all branches. The string "default" will be replaced with the git
+	// default branch.  Must use format "refs/remotes/origin/branch_name".
 	BranchList string `json:"branchList"`
 }
 
@@ -58,9 +58,11 @@ type RepoConfig struct {
 	// Action overrides the same setting in org-level, only if present.
 	Action *string `json:"action"`
 
-	// Comma-separated branch list to scan for Dangerous Workflows.
-	// Blank to scan all branches. The string "default" will be replaced with the git default branch.
-	// Must use format "refs/remotes/origin/branch_name".
+	// Comma-separated branch list to scan for Dangerous Workflows.  Blank to
+	// scan all branches. The string "default" will be replaced with the git
+	// default branch.  Must use format
+	// "refs/remotes/origin/branch_name". Repo-level list is additive to
+	// org-level list, it does not replace org-level list.
 	BranchList string `json:"branchList"`
 }
 
@@ -356,7 +358,7 @@ func configParseBranches(oc string, orc string, rc string) []string {
 	if orc != "" {
 		ret = append(ret, strings.Split(orc, ",")...)
 	}
-	if rc !="" {
+	if rc != "" {
 		ret = append(ret, strings.Split(rc, ",")...)
 	}
 	return ret

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-git/go-git/v5"
+	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	plumbinghttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-github/v59/github"

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -133,6 +133,26 @@ func (scc ScClient) FetchBranches() ([]string, error) {
 	return ret, nil
 }
 
+// Fetch default branch name from repo
+func (scc ScClient) GetDefaultBranchName() (string, error) {
+	refs, err := scc.gitRepo.References()
+	if err != nil {
+		return "", err
+	}
+
+	var ret string
+	err = refs.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Name() == "HEAD" && ref.Type() == plumbing.SymbolicReference {
+			ret = ref.Target().String()
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return ret, nil
+}
+
 // Checkout a repo into a local directory
 // returns the path to the local repo and a git repo reference
 func checkoutRepo(fullRepo string, token string) (string, *git.Repository, error) {


### PR DESCRIPTION
Add config option to specify branches for dangerous workflow, see https://github.com/ossf/allstar/pull/622#issuecomment-2740024164

Tested with and without option in `/.allstar/dangerous_workflow.yaml` file private branch to confirm this works as expected.