### PR TITLE
Add GitHub Actions image based on `cgr.dev/chainguard/node`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,16 +24,16 @@ jobs:
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
-      - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.workflow }} --password-stdin
+      - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor}} --password-stdin
 
       - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }} --image-refs allstar.ref
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
           KO_DEFAULTPLATFORMS: linux/arm64,linux/amd64
-      - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }}-busybox --image-refs allstar-busybox.ref
+      - run: ko publish -B ./cmd/allstar --tags ${{ github.ref_name }}-gha --image-refs allstar-gha.ref
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}
-          KO_DEFAULTBASEIMAGE: cgr.dev/chainguard/busybox
+          KO_DEFAULTBASEIMAGE: cgr.dev/chainguard/node:latest
           KO_DEFAULTPLATFORMS: linux/arm64,linux/amd64
       - run: |
           while read ref; do
@@ -43,11 +43,10 @@ jobs:
           while read ref; do
             echo "signing $ref"
             cosign sign --yes -a git_sha="$GITHUB_SHA" "$ref"
-          done < allstar-busybox.ref
-
+          done < allstar-gha.ref
       - run: |
           gh release create ${{ github.ref_name }} --notes "Images:
-          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}
-          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}-busybox"
+          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }} # Minimal image based on scratch
+          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}-gha # Image for use as a GitHub Action"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/policies/action/action.go
+++ b/pkg/policies/action/action.go
@@ -34,13 +34,16 @@ import (
 const (
 	configFile = "actions.yaml"
 	polName    = "GitHub Actions"
-)
 
-const failText = "This policy, specified at the organization level, sets requirements for Action use by repos within the organization. This repo is failing to fully comply with organization policies, as explained below.\n\n```\n%s```\n\nSee the org-level %s policy configuration for details."
+	failText = "This policy, specified at the organization level, sets requirements for Action use by repos within the organization. This repo is failing to fully comply with organization policies, as explained below.\n\n```\n%s```\n\nSee the org-level %s policy configuration for details."
 
-const (
 	maxWorkflows                  = 50
 	repoSelectorExcludeDepthLimit = 3
+
+	// Rule methods.
+	ruleMethodRequire = "require"
+	ruleMethodAllow   = "allow"
+	ruleMethodDeny    = "deny"
 )
 
 var priorities = map[string]int{
@@ -373,7 +376,7 @@ func (a Action) Check(ctx context.Context, c *github.Client, owner,
 	var headSHA string
 
 	for _, r := range applicableRules {
-		if r.Method == "require" { //nolint:goconst // TODO(lint): Re-enable linter (https://github.com/ossf/allstar/issues/716)
+		if r.Method == ruleMethodRequire {
 			if r.MustPass && wfr == nil {
 				var err error
 				hash, err := getLatestCommitHash(ctx, c, owner, repo)

--- a/pkg/policies/action/eval.go
+++ b/pkg/policies/action/eval.go
@@ -80,9 +80,9 @@ func evaluateActionDenied(ctx context.Context, c *github.Client, rules []*intern
 			continue
 		}
 		switch r.Method {
-		case "allow":
+		case ruleMethodAllow:
 			fallthrough
-		case "require":
+		case ruleMethodRequire:
 			if ruleMatch {
 				stepResult.status = denyRuleStepStatusAllowed
 				break
@@ -93,7 +93,7 @@ func evaluateActionDenied(ctx context.Context, c *github.Client, rules []*intern
 				break
 			}
 			stepResult.status = denyRuleStepStatusMissingAction
-		case "deny":
+		case ruleMethodDeny:
 			if ruleMatch {
 				stepResult.status = denyRuleStepStatusDenied
 				result.denied = true
@@ -124,7 +124,7 @@ func evaluateActionDenied(ctx context.Context, c *github.Client, rules []*intern
 func evaluateRequireRule(ctx context.Context, c *github.Client, owner, repo string, rule *internalRule,
 	actions []*actionMetadata, headSHA string, gc globCache, sc semverCache,
 ) (*requireRuleEvaluationResult, error) {
-	if rule.Method != "require" {
+	if rule.Method != ruleMethodRequire {
 		return nil, fmt.Errorf("rule is not a require rule")
 	}
 	useCount := 1


### PR DESCRIPTION
Chainguard changed the base image used for `chainguard/busybox` from Alpine to Wolfi. [See "Upcoming Changes"](https://images.chainguard.dev/directory/image/busybox/overview) This dropped libstdc++ which is required for node which is required for GitHub Actions to do things.

This change builds a new `allstar-gha` image that uses `chainguard/node:latest` which includes libstdc++. The `allstar-busybox` image is removed from the release workflow.

This also switches to using `github.actor` to login to GitHub Container Registry instead of `github.workflow`, following standard convention.