### PR TITLE
workflows: Add `stale` action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+permissions: read-all
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v3.0.18
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked stale because it has been open for 60 days with no activity.'
+        stale-pr-message: 'This pull request has been marked stale because it has been open for 10 days with no activity'
+        exempt-issue-labels: 'bug,good first issue,help wanted,maintainer,improvements'
+        days-before-pr-stale: '10'
+        days-before-pr-close: '20'
+        days-before-issue-stale: '60'
+        days-before-issue-close: -1
+        operations-per-run: '100'


### PR DESCRIPTION
Based on [`ossf/scorecard` `stale` configuration](https://github.com/ossf/scorecard/blob/f6ed084d17c9236477efd66e5b258b9d4cc7b389/.github/workflows/stale.yml).