### PR TITLE
Add documentation and sample code to run Allstar as a GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@
 -  [Background](#background)
 -  [Org-Level Options](#org-level-options)
 -  [Installation Options](#installation-options)
-    - [Quickstart Installation](#quickstart-installation)
-    - [Manual Installation](#manual-installation)
+    - [Using the public AllStar app](#using-the-allstar-app)
+        - [Quickstart Installation](#quickstart-installation)
+        - [Manual Installation](#manual-installation)
+    - [Self-hosting AllStar](#self-hosting-allstar)
+        - [Running AllStar as a GitHub Action](#running-allstar-as-a-github-action)
+        - [Running AllStar as a service daemon](#running-allstar-as-a-service-daemon)
 
 ## Policies and Actions
 - [Actions](#actions)
@@ -165,9 +169,15 @@ configured at the org level. </td>
 
 ### Installation Options
 
-Both the Quickstart and Manual Installation options involve installing the Allstar app. You may review the permissions requested. The app asks for read access to most settings and file contents to detect security compliance. It requests write access to issues and checks so that it can create issues and allow the `block` action.
+Both the [Quickstart](#quickstart-installation) and [Manual Installation](#manual-installation) options involve installing the [Allstar app](https://github.com/apps/allstar-app) into your GitHub Organization. The Allstar app is operated by [OpenSSF](https://openssf.org/) and is a good choice for most open source repositories. You may review the permissions requested. The app asks for read access to most settings and file contents to detect security compliance. It requests write access to issues and checks so that it can create issues and allow the `block` action.
 
-#### Quickstart Installation
+If you do not want to use the OpenSSF operated Allstar app you may [self-host Allstar](#self-hosting-allstar), creating your own Allstar app. This provides direct control of the app with a trade off of needing to configure, secure, monitor, and maintain the app.
+
+#### Using the Allstar app
+
+Quickstart or Manual installation are recommended unless you have specific security or compliance constraints that prevent you from using the OpenSSF managed Allstar app.
+
+##### Quickstart Installation
 This installation option will enable Allstar using the
 Opt Out strategy on all repositories in your  organization. All current policies
 will be enabled, and Allstar will alert you of
@@ -195,7 +205,7 @@ your repositories. Allstar will create an issue if a policy is violated.
 
 To change any configurations, see the [manual installation directions](manual-install.md).
 
-#### Manual Installation
+##### Manual Installation
 This installation option will walk you through creating
 configuration files according to either the Opt In or Opt Out strategy. This
 option provides more granular control over configurations right from the start.
@@ -208,6 +218,43 @@ Repositories" under Repository Access,  even if you don't plan to use Allstar on
 all your repositories)
 2) Follow the [manual installation directions](manual-install.md) to create org-level or
 repository-level Allstar config files and individual policy files.
+
+#### Self-hosting Allstar
+
+Only self-host if you must! The Allstar app requires configuration, securing,
+and ongoing maintenance. When a new Allstar version is released you will need
+to upgrade your self-hosted solution.
+
+Two self-hosting approaches are described:
+- [Running AllStar as a GitHub Action](#running-allstar-as-a-github-action) -
+  This option is relatively lightweight and leverages GitHub Actions to run
+  Allstar checks.
+- [Running AllStar as a service daemon](#running-allstar-as-a-service-daemon) -
+  This option has the highest level of control and assumes you are able to run
+  a persistent service on a reliable server or container orchestrator.
+
+##### Running Allstar as a GitHub Action
+This installation option runs Allstar as a scheduled job using GitHub Actions.
+
+Effort: high
+
+Follow the [GitHub Actions installation directions](github-actions-install.md) to:
+1. Create a new GitHub app for Allstar use.
+1. Create an organization level `.allstar` control repo as described in
+   [quickstart installation](#quickstart-installation) or
+   [manual installation](#manual-installation). (**Ignore the steps to install
+   the OpenSSF managed Allstar app into your organization.**)
+1. Setup a recurring GitHub Action in `.allstar` to run Allstar in batch mode.
+1. Monitor job activity and results.
+
+##### Running Allstar as a service daemon
+This installation option runs Allstar as a persistent process.
+
+Effort: very high
+
+See [Operator instructions](#operator-instructions) for more information
+including creating an Allstar app, managing secrets, and available environment
+variables.
 
 ## Policies and Actions
 

--- a/examples/gha-allstar-run.yml
+++ b/examples/gha-allstar-run.yml
@@ -1,0 +1,102 @@
+# Copy this file into your organization .allstar repo as `.github/workflows/allstar-run.yml`
+# to run AllStar as a scheduled GitHub action.
+# See https://github.com/ossf/allstar/blob/main/github-action-installtion.md for more information.
+---
+name: AllStar Enforcement Action
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # M-F at 6:00am UTC
+    - cron: '0 6 * * 1-5'
+
+env:
+  ARTIFACT_DIR: /tmp/artifacts
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    # Use chainguard/busybox based image - It has a tail for entrypoint
+    container:
+      # Specifying allstar by sha since tags are mutable.
+      # YOU ARE RESPONSIBLE FOR UPDATING THIS FINGERPRINT FOR NEW ALLSTAR RELEASES!
+      image: ghcr.io/ossf/allstar@sha256:a088ecec168b87733e454590a4a3ec9d927bbb4bcec6fe4829f52758f0e272e6 # v4.4.6-gha
+      options: --user root
+    environment: prod
+    steps:
+      - name: Create Artifact Directory
+        run: mkdir $ARTIFACT_DIR
+      - name: Run AllStar Policy Check
+        env:
+          # Ping open issues every week (168 hours)
+          NOTICE_PING_DURATION_HOURS: 168
+          DO_NOTHING_ON_OPT_OUT: true # consistent with https://github.com/ossf/allstar/blob/main/app-prod.yaml#L12
+          ALLSTAR_LOG_LEVEL: info
+          KEY_SECRET: direct
+          APP_ID: ${{ vars.APP_ID }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          /ko-app/allstar -once 2> $ARTIFACT_DIR/allstar.log | tee $ARTIFACT_DIR/allstar.out
+          test -s $ARTIFACT_DIR/allstar.log && echo "==== Errors ====" && cat $ARTIFACT_DIR/allstar.log
+      - name: Archive AllStar Results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @4.6.2
+        with:
+          name: allstar-scan
+          path: ${{ env.ARTIFACT_DIR }}
+
+  analyze:
+    runs-on: ubuntu-latest
+    needs: scan
+    environment: prod
+    steps:
+      - name: Download scan artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @4.3.0
+        with:
+          name: allstar-scan
+      - name: Make artifacts directory
+        run: mkdir $ARTIFACT_DIR
+      - name: Summarize Results by Check
+        run: |
+          grep '^{' $GITHUB_WORKSPACE/allstar.log |
+            jq --slurp '[.[] | select(.enabled == true and .message == "Policy run result.") ] |
+              group_by(.area) | map({
+                area: .[0].area,
+                summary: {
+                  pass_count: map(select(.result == true)) | length,
+                  fail_count: map(select(.result == false)) | length,
+                  passed: map(select(.result == true)| .repo),
+                  failed: map(select(.result == false)| .repo)
+                }
+              })' |
+            tee $ARTIFACT_DIR/scan_results_by_check.json
+      - name: Output Scan Results by Check to Step Summary
+        run: |
+          echo '## Scan Results by Check' >> $GITHUB_STEP_SUMMARY
+          SCAN_RESULTS=$(cat $ARTIFACT_DIR/scan_results_by_check.json)
+          echo "$SCAN_RESULTS" | jq -r '.[] | "\n<details>\n<summary>\(.area) - Pass: \(.summary.pass_count), Fail: \(.summary.fail_count)</summary>\n\n| Pass Count | Fail Count | Passed | Failed |\n| --- | --- | --- | --- |\n| \(.summary.pass_count) | \(.summary.fail_count) | \(.summary.passed | join(", ")) | \(.summary.failed | join(", ")) |\n\n</details>\n"' >> $GITHUB_STEP_SUMMARY
+      - name: Summarize Results by Repository
+        run: |
+          grep '^{' $GITHUB_WORKSPACE/allstar.log |
+            jq --slurp '[.[] | select(.enabled == true and .message == "Policy run result.") ] |
+              group_by(.repo) | map({
+                repository: .[0].repo,
+                summary: {
+                  pass_count: map(select(.result == true)) | length,
+                  fail_count: map(select(.result == false)) | length,
+                  passed: map(select(.result == true)| .area),
+                  failed: map(select(.result == false)| .area)
+                }
+              })' |
+            tee $ARTIFACT_DIR/scan_results_by_repo.json
+      - name: Output Scan Results by Repository to Step summary
+        run: |
+          echo '## Scan Results by Repository' >> $GITHUB_STEP_SUMMARY
+          SCAN_RESULTS_REPO=$(cat $ARTIFACT_DIR/scan_results_by_repo.json)
+          echo "$SCAN_RESULTS_REPO" | jq -r '.[] | "\n<details>\n<summary>\(.repository) - Pass: \(.summary.pass_count), Fail: \(.summary.fail_count)</summary>\n\n| Pass Count | Fail Count | Passed | Failed |\n| --- | --- | --- | --- |\n| \(.summary.pass_count) | \(.summary.fail_count) | \(.summary.passed | join(", ")) | \(.summary.failed | join(", ")) |\n\n</details>\n"' >> $GITHUB_STEP_SUMMARY
+      - name: Archive AllStar Results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @4.6.2
+        with:
+          name: allstar-results
+          path: ${{ env.ARTIFACT_DIR }}

--- a/github-action-installation.md
+++ b/github-action-installation.md
@@ -1,0 +1,118 @@
+# GitHub Action installation
+
+These directions will help you run Allstar via GitHub Actions. If at all
+possible, use the OpenSSF managed Allstar app instead (either using
+[quickstart](README.md#quickstart-installation) or
+[manual](README.md#manual-installation) methods) to avoid the burden of setup,
+securing, maintaining, and troubleshooting this solution.
+
+* [Create a GitHub App for Allstar](#create-a-github-app-for-allstar)
+* [Setup the Allstar GitHub Action](#setup-the-allstar-github-action)
+    * [Create your organization .allstar control repository](#create-your-organization-allstar-control-repository)
+    * [Setup a recurring GitHub Action to run Allstar](#setup-a-recurring-github-action-to-run-allstar)
+    * [Create the prod deployment environment](#create-the-prod-deployment-environment)
+* [Monitoring](#monitoring)
+* [Maintenance](#maintenance)
+    * [Update the version of Allstar image used](#update-the-version-of-allstar-image-used)
+
+## Create a GitHub App for Allstar
+
+An "App" is like a service account: It is a user-like thing with a set of
+permissions in your GitHub organization. Private key authentication can be used
+to allow a GitHub Action (or anything) to authenticate as the "App".
+
+See [Allstar - Operator - Create a GitHub App](operator.md#create-a-github-app)
+When you create the app user make sure to record the `App ID` value.
+
+## Setup the Allstar GitHub Action
+
+The Allstar GitHub Action requires some setup before it is usable in a new
+organization.
+
+### Create your organization .allstar control repository
+You must create a `.allstar` control repo to hold your Allstar configuration
+as well as the GitHub Actions job to run Allstar.
+
+The steps in [quickstart installation](README.md#quickstart-installation) or
+[manual installation](README.md#manual-installation) can be used to create the
+`.allstar` control repository. **Ignore the steps to install
+the OpenSSF managed Allstar app into your organization!**
+
+### Setup a recurring GitHub Action to run Allstar
+
+1. Copy [`examples/gha-allstar-run.yml`](https://github.com/ossf/allstar/blob/main/examples/gha-allstar-run.yml)
+   into `.github/workflows/allstar-run.yml` in your new `.allstar` control
+   repository.
+1. Edit `.github/workflows/allstar-run.yml`:
+  1. You can update when the job runs by modifying its `schedule`:
+     ~~~
+     schedule:
+       # M-F at 6:00am UTC
+       - cron: '0 6 * * 1-5'
+     ~~~
+  1. You should check the version of Allstar container image used and update it
+     if needed following [Update the version of Allstar image used](#update-the-version-of-allstar-image-used)
+1. Commit changes and merge into `main`
+
+The job will not function at this point.
+
+### Create the prod deployment environment
+
+To protect secrets we utilize the deployment environment feature of GitHub
+Actions.
+
+* In your GitHub organization under Settings -> Environments
+  create the `prod` environment
+* Uncheck "Allow administrators to bypass configured protection rules"
+* Under "Deployment branches" switch to "Selected Branches"
+* Click "Add deployment branch rule" and enter `main` then click "Add rule"
+* Under "Environment variables" click "Add variable"
+  * Name: `APP_ID`
+  * Value: Enter the App ID for the app user
+  * Click "Add variable" to complete
+* Under "Environment secrets" click "Add secret"
+  * Name: `PRIVATE_KEY`
+  * Value: Paste the contents of the private key PEM downloaded in [Private key](#private-key)
+  * Click "Add secret" to complete
+* From this point, future Allstar GitHub Action runs on `main` should function.
+
+## Monitoring
+
+The example GitHub Action includes a post-processing stage named `analyze` that
+parses Allstar output and generates a helpful overview. To see the summary:
+
+* Under your `.allstar` control repo navigate to the Actions tab
+* Under the Actions menu on the left, select "Allstar Enforcement Action"
+* A list of enforcement actions will be shown - Click the run you would like to
+  inspect
+* Under the standard GitHub action pipeline display the "analyze summary" should
+  be shown providing Scan Results by Check and Scan Results by Repository summaries
+* Two artifacts are also generated:
+  * `allstar-results.zip` - JSON versions of the analyze results
+  * `allstar-scan` - Raw logs and errors from the Allstar run
+
+## Maintenance
+
+### Update the version of Allstar image used
+
+The Allstar project publishes new container images as part of each release.
+These are available from the [allstar container repository](https://github.com/ossf/allstar/pkgs/container/allstar/versions?filters%5Bversion_type%5D=tagged).
+
+To update:
+
+* Open a PR to update [.github/workflows/allstar-run.yml](.github/workflows/allstar-run.yml)
+  with the new SHA256 fingerprint of the image you wish to use.
+  * To find the fingerprint, go to the [Allstar containers page](https://github.com/ossf/allstar/pkgs/container/allstar)
+    and find the most recent tag ending in `-gha` then click on `Digest ...`.
+    Copy the SHA256 fingerprint.
+  * Find the lines below in `allstar-run.yml` and update value after the `@`.
+    For example:
+
+  ~~~yaml
+  container:
+   image: ghcr.io/ossf/allstar@sha256:b9a32c3f54f3e96aa06003eb48acb9d4c32a70b5ec49bdc4f91b942b32b14969 # v4.4-gha
+  ~~~
+
+* Once reviewed and merged make sure to monitor the action under
+  Actions and address any issues.
+


### PR DESCRIPTION
Addresses https://github.com/ossf/allstar/issues/721

* Adds documentation on running Allstar as a GitHub Action to `README.md` and `github-action-installation.md`.
* Adds sample GitHub Actions code under `examples/gha-allstar-run.yml`.

Note that the issue suggested adding the documentation to `operator.md`. That did not seem to flow as well, but I am happy to blend `github-action-installation.md` into `operator.md` if folks prefer.

I see some significant Markdown changes in #728 and will rebase and revise this PR if that is merged.