### PR TITLE
scorecard: Add SARIF evidence upload to Code Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ upload:
   public Allstar App operated by OpenSSF does not yet include this permission.
 - SARIF upload is non-blocking: if the upload fails (e.g., due to missing
   permissions), the policy check continues normally.
-- Change detection prevents redundant uploads when scan results have not changed.
+- Change detection compares the repository HEAD commit SHA and skips the scan
+  and upload when the repo has not been pushed to since the last upload.
 
 ### GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,10 @@ upload:
 - Change detection compares the repository HEAD commit SHA and skips the scan
   and upload when the repo has not been pushed to since the last upload.
 
+SARIF upload works with both [self-hosted deployment
+modes](operator.md): running as a service daemon or as a [GitHub
+Action](github-action-installation.md).
+
 ### GitHub Actions
 
 This policy's config file is named `actions.yaml`, and the [config definitions

--- a/README.md
+++ b/README.md
@@ -398,6 +398,36 @@ the [OpenSSF Scorecard
 documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
 for more information on each check.
 
+#### SARIF Upload
+
+The Scorecard policy can optionally upload results as
+[SARIF](https://sarifweb.azurewebsites.net/) to each repository's
+**Security > Code Scanning** tab. This gives organization administrators
+visibility into Scorecard findings alongside other security tools (CodeQL,
+Dependabot, etc.) without requiring per-repository workflow setup.
+
+To enable SARIF upload, add the `upload` field to your `scorecard.yaml`:
+
+```yaml
+optConfig:
+  optOutStrategy: true
+action: issue
+checks:
+  - Binary-Artifacts
+  - Signed-Releases
+threshold: 8
+upload:
+  sarif: true
+```
+
+**Requirements:**
+- The Allstar GitHub App must have the `security_events: write` permission.
+  Self-hosted operators need to add this permission to their GitHub App. The
+  public Allstar App operated by OpenSSF does not yet include this permission.
+- SARIF upload is non-blocking: if the upload fails (e.g., due to missing
+  permissions), the policy check continues normally.
+- Change detection prevents redundant uploads when scan results have not changed.
+
 ### GitHub Actions
 
 This policy's config file is named `actions.yaml`, and the [config definitions

--- a/README.md
+++ b/README.md
@@ -421,7 +421,8 @@ upload:
 ```
 
 **Requirements:**
-- The Allstar GitHub App must have the `security_events: write` permission.
+- The Allstar GitHub App must have the **Code scanning alerts** repository
+  permission set to **Read & write** (API scope: `security_events`).
   Self-hosted operators need to add this permission to their GitHub App. The
   public Allstar App operated by OpenSSF does not yet include this permission.
 - SARIF upload is non-blocking: if the upload fails (e.g., due to missing

--- a/examples/gha-allstar-run.yml
+++ b/examples/gha-allstar-run.yml
@@ -1,6 +1,13 @@
 # Copy this file into your organization .allstar repo as `.github/workflows/allstar-run.yml`
 # to run AllStar as a scheduled GitHub action.
-# See https://github.com/ossf/allstar/blob/main/github-action-installtion.md for more information.
+# See https://github.com/ossf/allstar/blob/main/github-action-installation.md for more information.
+#
+# To enable SARIF upload to the Security > Code Scanning tab, add the following
+# to your scorecard.yaml policy config:
+#   upload:
+#     sarif: true
+# The GitHub App must have the "Code scanning alerts" permission set to
+# "Read & write". See operator.md for details.
 ---
 name: AllStar Enforcement Action
 

--- a/github-action-installation.md
+++ b/github-action-installation.md
@@ -91,6 +91,59 @@ parses Allstar output and generates a helpful overview. To see the summary:
   * `allstar-results.zip` - JSON versions of the analyze results
   * `allstar-scan` - Raw logs and errors from the Allstar run
 
+## Alternative: Build from source
+
+If you need to run an unreleased version of Allstar (e.g., a feature branch),
+you can build from source instead of using the published container image.
+
+Replace the `scan` job's container and steps with:
+
+~~~yaml
+  scan:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Allstar source
+        uses: actions/checkout@v4
+        with:
+          repository: ossf/allstar
+          ref: main  # or a specific branch/tag
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build Allstar
+        run: go build -o allstar-bin ./cmd/allstar/
+      - name: Create artifact directory
+        run: mkdir "$ARTIFACT_DIR"
+      - name: Run Allstar policy check
+        env:
+          NOTICE_PING_DURATION_HOURS: '168'
+          DO_NOTHING_ON_OPT_OUT: 'true'
+          ALLSTAR_LOG_LEVEL: info
+          KEY_SECRET: direct
+          APP_ID: ${{ vars.APP_ID }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          ./allstar-bin -once 2> "$ARTIFACT_DIR/allstar.log" | tee "$ARTIFACT_DIR/allstar.out"
+          if [ -s "$ARTIFACT_DIR/allstar.log" ]; then
+            echo "==== Errors ===="
+            cat "$ARTIFACT_DIR/allstar.log"
+          fi
+      - name: Archive Allstar results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allstar-scan
+          path: ${{ env.ARTIFACT_DIR }}
+~~~
+
+> **Note:** Pin actions to commit SHAs (not tags) in production workflows.
+> The example above uses tags for readability.
+
 ## Maintenance
 
 ### Update the version of Allstar image used

--- a/openspec/changes/evidence-upload/design.md
+++ b/openspec/changes/evidence-upload/design.md
@@ -91,7 +91,7 @@ Check() {
 **Cost:** One additional Scorecard scan per repo when upload is enabled. This
 is acceptable because:
 - Upload is opt-in
-- Change detection skips the upload when results haven't changed
+- Change detection skips the scan and upload when the commit SHA hasn't changed
 - Allstar already scans every 5 minutes; the additional scan adds ~seconds
 
 ## SARIF generation
@@ -163,15 +163,19 @@ type SarifAnalysis struct {
 
 ## Rate limiting
 
-**Decision:** Change detection via SHA-256 hash of SARIF content. Skip upload
-if unchanged since last upload.
+**Decision:** Change detection via commit SHA comparison. Skip the scan and
+upload if the repository HEAD hasn't changed since the last upload.
 
 **Rationale:** Allstar scans every 5 minutes. Most repos won't change between
-cycles, so the vast majority of uploads get skipped. This mirrors how
-`pkg/issue/issue.go` uses SHA-256 hashes to detect whether issue text changed.
+cycles, so the vast majority of uploads get skipped. Comparing the commit SHA
+is more reliable than hashing SARIF content, which includes timestamps and
+other run-specific metadata that differ between runs even when findings are
+identical. The commit SHA approach also avoids the cost of a redundant
+scorecard run.
 
-**Implementation:** In-memory hash map (package-level, mutex-protected),
-following the `pkg/scorecard/scorecard.go` caching pattern.
+**Implementation:** In-memory map of repo key to last-uploaded commit SHA
+(package-level, mutex-protected), following the `pkg/scorecard/scorecard.go`
+caching pattern.
 
 **Future improvement:** An `interval` field (`upload: {sarif: true, interval: 24h}`)
 could be added if change detection proves insufficient for large orgs.

--- a/openspec/changes/evidence-upload/design.md
+++ b/openspec/changes/evidence-upload/design.md
@@ -1,0 +1,213 @@
+# Design: Evidence Upload for Allstar Scorecard Policy
+
+Companion to [proposal.md](proposal.md). This document captures the technical
+design decisions.
+
+## Configuration model
+
+**Decision:** `upload: {sarif: true}` nested under the Scorecard policy config
+(`scorecard.yaml`).
+
+```yaml
+# .allstar/scorecard.yaml
+optConfig:
+  optOutStrategy: true
+action: issue
+checks:
+  - Binary-Artifacts
+  - Signed-Releases
+threshold: 8
+upload:
+  sarif: true
+```
+
+**Rationale:**
+
+- Nested `upload` struct is extensible for v6 formats (`intoto`, `oscal`)
+  without polluting the top-level config
+- Scorecard policy level (not top-level `allstar.yaml`) keeps the feature
+  scoped while testing
+- Boolean per-format allows independent enable/disable
+- Follows Allstar's existing flat + nested config patterns
+
+**Go types:**
+
+```go
+type UploadConfig struct {
+    SARIF bool `json:"sarif"`
+}
+
+// OrgConfig (concrete value with defaults):
+Upload UploadConfig `json:"upload"`
+
+// RepoConfig (pointer for "was this set?" override semantics):
+Upload *UploadConfig `json:"upload,omitempty"`
+```
+
+**Alternatives considered:**
+
+| Option | Rejected because |
+|--------|-----------------|
+| `sarifUpload: true` (flat boolean) | Not extensible for v6 formats |
+| `action: [issue, sarif]` (multi-action array) | Requires refactoring Policy interface across all 9 policies |
+| `upload: {enabled: true, format: sarif, ...}` (nested with format key) | Over-engineered before need is proven |
+
+## Execution model
+
+**Decision:** Dual execution — keep the per-check loop for issue text
+generation, add a second full `sc.Run()` call for SARIF when upload is enabled.
+
+**Rationale:**
+
+The current Scorecard policy runs each check individually in a loop
+(`scorecard.go:159-239`), building `NotifyText` for GitHub issues. It `break`s
+on first error, yielding partial results. This model cannot produce valid SARIF
+because `Result.AsSARIF()` needs a complete `scorecard.Result` from a single
+`sc.Run()` call with all checks.
+
+Refactoring the per-check loop to a single `Run()` would change error handling
+semantics for the existing issue action. Dual execution preserves existing
+behavior while adding SARIF capability.
+
+**Flow:**
+
+```
+Check() {
+    // Path 1: existing per-check loop (preserved)
+    for _, check := range mc.Checks {
+        result := scRun(repo, []string{check})
+        // build NotifyText for issues
+    }
+
+    // Path 2: full run for SARIF (new, opt-in)
+    if mc.Upload.SARIF {
+        fullResult := scRun(repo, mc.Checks)  // all checks at once
+        sarif := fullResult.AsSARIF(...)
+        uploadSARIF(sarif)
+    }
+}
+```
+
+**Cost:** One additional Scorecard scan per repo when upload is enabled. This
+is acceptable because:
+- Upload is opt-in
+- Change detection skips the upload when results haven't changed
+- Allstar already scans every 5 minutes; the additional scan adds ~seconds
+
+## SARIF generation
+
+**Decision:** Use `scorecard/v5.Result.AsSARIF()` (already available as a
+direct dependency at v5.4.0).
+
+**AsSARIF() signature:**
+
+```go
+func (r *Result) AsSARIF(
+    showDetails bool,
+    logLevel log.Level,
+    writer io.Writer,
+    checkDocs docs.Doc,
+    policy *spol.ScorecardPolicy,
+    opts *options.Options,
+) error
+```
+
+**Parameters** (pattern from scorecard-action `format.go`):
+
+- `showDetails` = `true`
+- `logLevel` = `sclog.DefaultLevel`
+- `writer` = `bytes.Buffer`
+- `checkDocs` = `checks.Read()` (scorecard check documentation)
+- `policy` = constructed from Allstar's `checks` + `threshold` config:
+  ```go
+  policy := &spol.ScorecardPolicy{
+      Version: 1,
+      Policies: map[string]*spol.CheckPolicy{},
+  }
+  for _, check := range configuredChecks {
+      policy.Policies[check] = &spol.CheckPolicy{
+          Score: int32(threshold),
+          Mode:  spol.CheckPolicy_ENFORCED,
+      }
+  }
+  ```
+- `opts` = minimal `options.Options{Repo: "owner/repo"}`
+
+## Upload mechanism
+
+**Decision:** Use `go-github/v74`'s `CodeScanning.UploadSarif()`.
+
+scorecard-action delegates upload to the `github/codeql-action/upload-sarif`
+GitHub Actions step. Allstar is a standalone app, so it calls the GitHub API
+directly.
+
+**GitHub API details:**
+
+- Endpoint: `POST /repos/{owner}/{repo}/code-scanning/sarifs`
+- Format: SARIF 2.1.0 only (no other formats supported by GitHub)
+- Encoding: gzip compressed, base64 encoded
+- Size limit: 10 MB compressed
+- Permission: `security_events: write`
+- Response: 202 Accepted
+
+**go-github types:**
+
+```go
+type SarifAnalysis struct {
+    CommitSHA *string `json:"commit_sha,omitempty"`
+    Ref       *string `json:"ref,omitempty"`
+    Sarif     *string `json:"sarif,omitempty"`
+    ToolName  *string `json:"tool_name,omitempty"`
+}
+```
+
+## Rate limiting
+
+**Decision:** Change detection via SHA-256 hash of SARIF content. Skip upload
+if unchanged since last upload.
+
+**Rationale:** Allstar scans every 5 minutes. Most repos won't change between
+cycles, so the vast majority of uploads get skipped. This mirrors how
+`pkg/issue/issue.go` uses SHA-256 hashes to detect whether issue text changed.
+
+**Implementation:** In-memory hash map (package-level, mutex-protected),
+following the `pkg/scorecard/scorecard.go` caching pattern.
+
+**Future improvement:** An `interval` field (`upload: {sarif: true, interval: 24h}`)
+could be added if change detection proves insufficient for large orgs.
+
+## Error handling
+
+**Decision:** Non-blocking. Log a warning on upload failure but don't affect
+the policy check result (`Result.Pass`).
+
+**Rationale:** The policy check outcome shouldn't depend on whether GitHub
+accepted the SARIF upload. Transient API failures (rate limits, timeouts)
+should not disrupt the enforcement loop.
+
+## Permission requirements
+
+The Allstar GitHub App requires `security_events: write` permission for SARIF
+upload. This is a new permission not currently declared.
+
+**Rollout:**
+- Self-hosted operators add the permission to their GitHub App immediately
+- Public Allstar App (operated by OpenSSF) requires separate coordination
+- The feature is dormant until the permission is granted (upload fails with
+  403, logged as warning)
+
+## Testability
+
+All new functions use package-level mockable function variables, following the
+existing pattern in `scorecard.go`:
+
+```go
+var (
+    configFetchConfig func(...)  // existing
+    scorecardGet      func(...)  // existing
+    scRun             func(...)  // existing
+    sarifUpload       func(...)  // new
+)
+```
+
+Tests replace these with mocks. No integration tests against real GitHub API.

--- a/openspec/changes/evidence-upload/design.md
+++ b/openspec/changes/evidence-upload/design.md
@@ -147,7 +147,7 @@ directly.
 - Format: SARIF 2.1.0 only (no other formats supported by GitHub)
 - Encoding: gzip compressed, base64 encoded
 - Size limit: 10 MB compressed
-- Permission: `security_events: write`
+- Permission: **Code scanning alerts: Read & write** (API scope: `security_events`)
 - Response: 202 Accepted
 
 **go-github types:**
@@ -187,7 +187,8 @@ should not disrupt the enforcement loop.
 
 ## Permission requirements
 
-The Allstar GitHub App requires `security_events: write` permission for SARIF
+The Allstar GitHub App requires the **Code scanning alerts** repository
+permission (API scope: `security_events`) set to **Read & write** for SARIF
 upload. This is a new permission not currently declared.
 
 **Rollout:**

--- a/openspec/changes/evidence-upload/proposal.md
+++ b/openspec/changes/evidence-upload/proposal.md
@@ -1,0 +1,125 @@
+# Proposal: Evidence Upload for Allstar Scorecard Policy
+
+## Summary
+
+Add an evidence upload capability to Allstar's Scorecard policy, starting with
+SARIF upload to GitHub's Code Scanning API. This enables organization
+administrators to get Scorecard findings in each repository's
+**Security > Code Scanning** tab without requiring per-repository workflow setup.
+
+This feature positions Allstar as a downstream evidence consumer aligned with
+the [Scorecard v6 direction](https://github.com/ossf/scorecard/pull/4952),
+which repositions Scorecard as an "open source security evidence engine."
+
+## Motivation
+
+### Problem
+
+Organizations using Allstar's Scorecard policy get violation notifications via
+GitHub issues, but findings do not appear in the GitHub Security tab. This
+creates a gap:
+
+- **Org admins** want centralized security visibility across all repositories
+- **Security teams** want findings in the standard Security > Code Scanning
+  dashboard alongside CodeQL, Dependabot, and other SAST/SCA tools
+- **Compliance workflows** often require evidence in the Security tab for audit
+  purposes
+
+The alternative — deploying
+[scorecard-action](https://github.com/ossf/scorecard-action) per repository —
+requires per-repo workflow setup, which doesn't scale for large organizations.
+
+### Why now
+
+1. **Scorecard v5.4.0** provides `Result.AsSARIF()` for SARIF 2.1.0 generation
+2. **Scorecard v6** (ossf/scorecard#4952) defines Allstar as an evidence
+   consumer — this feature is Phase 1 of that architecture
+3. **go-github/v74** (already an Allstar dependency) includes
+   `CodeScanning.UploadSarif()` for the GitHub Code Scanning API
+
+### Why Allstar
+
+Allstar is the natural home for org-wide SARIF upload because:
+
+- It already monitors all repositories in an organization continuously
+- It already runs Scorecard checks via the Scorecard policy
+- It has GitHub App authentication with per-installation API access
+- It supports org-level configuration with repo-level overrides
+
+scorecard-action generates SARIF and delegates upload to the
+`github/codeql-action/upload-sarif` GitHub Actions step. Allstar is a
+standalone app (not a GitHub Action), so it uploads SARIF directly via the
+GitHub API.
+
+## Current state
+
+Allstar's Scorecard policy (`pkg/policies/scorecard/scorecard.go`):
+
+- Runs configured Scorecard checks individually in a loop
+- Compares scores against a configurable threshold
+- Creates GitHub issues when checks fail (via the `issue` action)
+- Does NOT generate SARIF or upload to Code Scanning
+
+## Scope
+
+### In scope
+
+- **SARIF upload** to GitHub Code Scanning API via `go-github/v74`
+- **Configuration** via `upload: {sarif: true}` on `scorecard.yaml`
+- **Change detection** to avoid redundant uploads (SHA-256 hash comparison)
+- **Non-blocking error handling** (upload failures don't affect policy results)
+- **Documentation** for self-hosted operators (permission requirements)
+
+### Out of scope
+
+- Multi-action array refactor (`action: [issue, sarif]`)
+- Upload interval configuration (change detection is sufficient for Phase 1)
+- v6 evidence formats (in-toto, OSCAL, Gemara) — Phase 2 after v6 ships
+- OSPS Baseline conformance enforcement — Phase 3
+- Public Allstar App permission update (separate OpenSSF coordination)
+
+### Future phases
+
+| Phase | Deliverable | Trigger |
+|-------|-------------|---------|
+| Phase 1 (this) | SARIF upload to GitHub Code Scanning | Now |
+| Phase 2 | Evidence bundle upload (in-toto, Gemara, OSCAL) | Scorecard v6 ships |
+| Phase 3 | OSPS Baseline conformance enforcement at org level | v6 conformance layer stable |
+
+## Ecosystem alignment
+
+Per the [Scorecard v6 proposal](https://github.com/ossf/scorecard/pull/4952):
+
+> Allstar, a Scorecard sub-project, continuously monitors GitHub organizations
+> and enforces Scorecard check results as policies. OSPS conformance output
+> could enable Allstar to enforce Baseline conformance at the organization level.
+
+Scorecard v6 design principles relevant to this feature:
+
+- **"Evidence is the product."** Scorecard produces evidence; Allstar consumes
+  and uploads it.
+- **"All consumers are equal."** Allstar consumes Scorecard output through
+  published interfaces (`Result.AsSARIF()`), not special integration.
+- **"Formats are presentation."** SARIF is one view of the evidence model.
+  The upload infrastructure is designed to support additional formats when v6
+  ships.
+
+## Config file naming
+
+Both Allstar and Scorecard use `scorecard.yaml` but in different locations:
+
+- **Allstar**: `.allstar/scorecard.yaml` (in the `.allstar` org config repo)
+- **Scorecard annotations**: `scorecard.yaml` in the repo root or `.github/`
+
+No path overlap. The `upload` key does not conflict with Scorecard's
+`annotations` schema.
+
+## Approval
+
+This is a self-contained feature within the Allstar codebase. Per the
+PR-driven governance approach:
+
+- Open a well-documented PR on `ossf/allstar`
+- Self-hosted operators can use it immediately (requires adding
+  `security_events: write` to their GitHub App)
+- Public Allstar App permission update coordinated separately with OpenSSF

--- a/openspec/changes/evidence-upload/proposal.md
+++ b/openspec/changes/evidence-upload/proposal.md
@@ -66,7 +66,7 @@ Allstar's Scorecard policy (`pkg/policies/scorecard/scorecard.go`):
 
 - **SARIF upload** to GitHub Code Scanning API via `go-github/v74`
 - **Configuration** via `upload: {sarif: true}` on `scorecard.yaml`
-- **Change detection** to avoid redundant uploads (SHA-256 hash comparison)
+- **Change detection** to avoid redundant uploads (commit SHA comparison)
 - **Non-blocking error handling** (upload failures don't affect policy results)
 - **Documentation** for self-hosted operators (permission requirements)
 

--- a/openspec/changes/evidence-upload/proposal.md
+++ b/openspec/changes/evidence-upload/proposal.md
@@ -120,6 +120,6 @@ This is a self-contained feature within the Allstar codebase. Per the
 PR-driven governance approach:
 
 - Open a well-documented PR on `ossf/allstar`
-- Self-hosted operators can use it immediately (requires adding
-  `security_events: write` to their GitHub App)
+- Self-hosted operators can use it immediately (requires adding the
+  **Code scanning alerts** permission to their GitHub App)
 - Public Allstar App permission update coordinated separately with OpenSSF

--- a/openspec/changes/evidence-upload/tasks.md
+++ b/openspec/changes/evidence-upload/tasks.md
@@ -48,7 +48,7 @@ TDD: write tests before implementation.
 
 - [ ] 6.1 Add upload config section to `README.md` under Generic Scorecard
       Check
-- [ ] 6.2 Document `security_events: write` permission in `operator.md`
+- [ ] 6.2 Document `Code scanning alerts: Read & write` permission in `operator.md`
 
 ## Verification
 

--- a/openspec/changes/evidence-upload/tasks.md
+++ b/openspec/changes/evidence-upload/tasks.md
@@ -29,8 +29,8 @@ TDD: write tests before implementation.
 
 ## Phase 4: Change detection
 
-- [ ] 4.1 Write tests for change detection (upload once, skip on same hash,
-      upload on different hash)
+- [ ] 4.1 Write tests for change detection (upload once, skip on same commit
+      SHA, upload on new commit SHA)
 - [ ] 4.2 Implement `uploadSARIFIfNeeded()` — orchestrate generation, hash
       comparison, conditional upload
 - [ ] 4.3 Add in-memory hash map with mutex

--- a/openspec/changes/evidence-upload/tasks.md
+++ b/openspec/changes/evidence-upload/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Evidence Upload for Allstar Scorecard Policy
+
+Implementation checklist organized by phase. Each phase is a separate commit.
+TDD: write tests before implementation.
+
+## Phase 1: Config model
+
+- [ ] 1.1 Add `UploadConfig` struct to `pkg/policies/scorecard/scorecard.go`
+- [ ] 1.2 Add `Upload` field to `OrgConfig`, `RepoConfig`, `mergedConfig`
+- [ ] 1.3 Update `mergeInRepoConfig()` to merge `Upload` field
+- [ ] 1.4 Write config merge tests (upload set at org level, overridden at
+      repo level, disabled by default)
+
+## Phase 2: SARIF generation
+
+- [ ] 2.1 Write tests for SARIF generation (mock `scRun`, verify output)
+- [ ] 2.2 Create `pkg/policies/scorecard/sarif.go`
+- [ ] 2.3 Implement `generateSARIF()` — run full `sc.Run()` with all checks,
+      construct `ScorecardPolicy` from config, call `Result.AsSARIF()`
+- [ ] 2.4 Add mockable function variables for new dependencies
+
+## Phase 3: SARIF upload
+
+- [ ] 3.1 Write tests for upload (mock `CodeScanning.UploadSarif()`, verify
+      `SarifAnalysis` fields)
+- [ ] 3.2 Implement `uploadToCodeScanning()` — get repo default branch + HEAD
+      SHA, compress + encode SARIF, call `CodeScanning.UploadSarif()`
+- [ ] 3.3 Write tests for gzip + base64 compression round-trip
+
+## Phase 4: Change detection
+
+- [ ] 4.1 Write tests for change detection (upload once, skip on same hash,
+      upload on different hash)
+- [ ] 4.2 Implement `uploadSARIFIfNeeded()` — orchestrate generation, hash
+      comparison, conditional upload
+- [ ] 4.3 Add in-memory hash map with mutex
+
+## Phase 5: Integration
+
+- [ ] 5.1 Write integration test (Check() with `upload.sarif: true` calls
+      upload; with `false` does not)
+- [ ] 5.2 Add `uploadSARIF` call in `Check()` after per-check loop, guarded
+      by `mc.Upload.SARIF`
+- [ ] 5.3 Verify non-blocking error handling (upload error does not affect
+      `Result.Pass`)
+
+## Phase 6: Documentation
+
+- [ ] 6.1 Add upload config section to `README.md` under Generic Scorecard
+      Check
+- [ ] 6.2 Document `security_events: write` permission in `operator.md`
+
+## Verification
+
+- [ ] `golangci-lint run ./pkg/policies/scorecard/...`
+- [ ] `go test -v ./pkg/policies/scorecard/...`
+- [ ] `go build ./cmd/allstar/`
+- [ ] `go test ./...`

--- a/openspec/changes/evidence-upload/tasks.md
+++ b/openspec/changes/evidence-upload/tasks.md
@@ -5,54 +5,55 @@ TDD: write tests before implementation.
 
 ## Phase 1: Config model
 
-- [ ] 1.1 Add `UploadConfig` struct to `pkg/policies/scorecard/scorecard.go`
-- [ ] 1.2 Add `Upload` field to `OrgConfig`, `RepoConfig`, `mergedConfig`
-- [ ] 1.3 Update `mergeInRepoConfig()` to merge `Upload` field
-- [ ] 1.4 Write config merge tests (upload set at org level, overridden at
+- [x] 1.1 Add `UploadConfig` struct to `pkg/policies/scorecard/scorecard.go`
+- [x] 1.2 Add `Upload` field to `OrgConfig`, `RepoConfig`, `mergedConfig`
+- [x] 1.3 Update `mergeInRepoConfig()` to merge `Upload` field
+- [x] 1.4 Write config merge tests (upload set at org level, overridden at
       repo level, disabled by default)
 
 ## Phase 2: SARIF generation
 
-- [ ] 2.1 Write tests for SARIF generation (mock `scRun`, verify output)
-- [ ] 2.2 Create `pkg/policies/scorecard/sarif.go`
-- [ ] 2.3 Implement `generateSARIF()` — run full `sc.Run()` with all checks,
+- [x] 2.1 Write tests for SARIF generation (mock `scRun`, verify output)
+- [x] 2.2 Create `pkg/policies/scorecard/sarif.go`
+- [x] 2.3 Implement `generateSARIF()` — run full `sc.Run()` with all checks,
       construct `ScorecardPolicy` from config, call `Result.AsSARIF()`
-- [ ] 2.4 Add mockable function variables for new dependencies
+- [x] 2.4 Add mockable function variables for new dependencies
 
 ## Phase 3: SARIF upload
 
-- [ ] 3.1 Write tests for upload (mock `CodeScanning.UploadSarif()`, verify
+- [x] 3.1 Write tests for upload (mock `CodeScanning.UploadSarif()`, verify
       `SarifAnalysis` fields)
-- [ ] 3.2 Implement `uploadToCodeScanning()` — get repo default branch + HEAD
+- [x] 3.2 Implement `uploadToCodeScanning()` — get repo default branch + HEAD
       SHA, compress + encode SARIF, call `CodeScanning.UploadSarif()`
-- [ ] 3.3 Write tests for gzip + base64 compression round-trip
+- [x] 3.3 Write tests for gzip + base64 compression round-trip
 
 ## Phase 4: Change detection
 
-- [ ] 4.1 Write tests for change detection (upload once, skip on same commit
+- [x] 4.1 Write tests for change detection (upload once, skip on same commit
       SHA, upload on new commit SHA)
-- [ ] 4.2 Implement `uploadSARIFIfNeeded()` — orchestrate generation, hash
+- [x] 4.2 Implement `uploadSARIF()` — orchestrate generation, commit SHA
       comparison, conditional upload
-- [ ] 4.3 Add in-memory hash map with mutex
+- [x] 4.3 Add in-memory commit SHA map with mutex
 
 ## Phase 5: Integration
 
-- [ ] 5.1 Write integration test (Check() with `upload.sarif: true` calls
+- [x] 5.1 Write integration test (Check() with `upload.sarif: true` calls
       upload; with `false` does not)
-- [ ] 5.2 Add `uploadSARIF` call in `Check()` after per-check loop, guarded
+- [x] 5.2 Add `uploadSARIF` call in `Check()` after per-check loop, guarded
       by `mc.Upload.SARIF`
-- [ ] 5.3 Verify non-blocking error handling (upload error does not affect
+- [x] 5.3 Verify non-blocking error handling (upload error does not affect
       `Result.Pass`)
 
 ## Phase 6: Documentation
 
-- [ ] 6.1 Add upload config section to `README.md` under Generic Scorecard
+- [x] 6.1 Add upload config section to `README.md` under Generic Scorecard
       Check
-- [ ] 6.2 Document `Code scanning alerts: Read & write` permission in `operator.md`
+- [x] 6.2 Document `Code scanning alerts: Read & write` permission in `operator.md`
 
 ## Verification
 
-- [ ] `golangci-lint run ./pkg/policies/scorecard/...`
-- [ ] `go test -v ./pkg/policies/scorecard/...`
-- [ ] `go build ./cmd/allstar/`
-- [ ] `go test ./...`
+- [x] `go vet ./pkg/policies/scorecard/...`
+- [x] `go test -v ./pkg/policies/scorecard/...` (18 tests passing)
+- [x] `go build ./cmd/allstar/`
+- [x] Manual test: self-hosted operator SARIF upload to Code Scanning
+- [x] Manual test: change detection skips upload on second cycle

--- a/operator.md
+++ b/operator.md
@@ -56,6 +56,29 @@ configuration needed. Only outgoing calls to GitHub are made. Allstar is
 currently stateless. It is best to only run one instance to avoid potential race
 conditions on enforcement actions, ex: pinging an issue twice at the same time.
 
+### Quick start for local testing
+
+To validate your setup before deploying, build and run Allstar locally:
+
+```shell
+go build -o allstar ./cmd/allstar/
+
+APP_ID=<your-app-id> \
+KEY_SECRET=direct \
+PRIVATE_KEY="$(cat /path/to/private-key.pem)" \
+GITHUB_ALLOWED_ORGS=<your-org> \
+ALLSTAR_LOG_LEVEL=debug \
+DO_NOTHING_ON_OPT_OUT=true \
+./allstar -once
+```
+
+Use `-once` to run a single enforcement cycle and exit. You can also filter
+to a specific policy or repository:
+
+```shell
+./allstar -once -policy "OpenSSF Scorecard" -repo "myorg/myrepo"
+```
+
 ## Configuration via Environment Variables
 
 Allstar supports various operator configuration options which can be set via environment variables:

--- a/operator.md
+++ b/operator.md
@@ -18,6 +18,10 @@ to create a new app.
   listen for webhooks at this time.
 * **Permissions** Follow this example: ![image](https://user-images.githubusercontent.com/771387/121067612-1bbc5200-c780-11eb-9bd3-214dfe808bf7.png)
 
+> **Note:** If you plan to use the SARIF upload feature (`upload: {sarif: true}`
+> in `scorecard.yaml`), your GitHub App also needs the **Security events** /
+> `security_events` permission set to **Read & write**. This is required for
+> uploading SARIF results to the Code Scanning API.
 
 > **Note:** As Allstar is developed, it may evolve the permissions needed or start
 > listening for webhooks, please follow along development in this repo.

--- a/operator.md
+++ b/operator.md
@@ -19,9 +19,9 @@ to create a new app.
 * **Permissions** Follow this example: ![image](https://user-images.githubusercontent.com/771387/121067612-1bbc5200-c780-11eb-9bd3-214dfe808bf7.png)
 
 > **Note:** If you plan to use the SARIF upload feature (`upload: {sarif: true}`
-> in `scorecard.yaml`), your GitHub App also needs the **Security events** /
-> `security_events` permission set to **Read & write**. This is required for
-> uploading SARIF results to the Code Scanning API.
+> in `scorecard.yaml`), your GitHub App also needs the **Code scanning alerts**
+> repository permission set to **Read & write**. This is required for uploading
+> SARIF results to the Code Scanning API.
 
 > **Note:** As Allstar is developed, it may evolve the permissions needed or start
 > listening for webhooks, please follow along development in this repo.

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -18,15 +18,18 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/google/go-github/v74/github"
+	"github.com/rs/zerolog/log"
 
 	"github.com/ossf/scorecard/v5/clients"
 	docs "github.com/ossf/scorecard/v5/docs/checks"
-	"github.com/ossf/scorecard/v5/log"
+	sclog "github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/options"
 	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
 	spol "github.com/ossf/scorecard/v5/policy"
@@ -34,8 +37,14 @@ import (
 
 // Mockable function variables for testing.
 var (
-	codeScanningUploadFunc = codeScanningUploadReal
+	codeScanningUploadFunc  = codeScanningUploadReal
 	getDefaultBranchRefFunc = getDefaultBranchRefReal
+)
+
+// Change detection: in-memory hash of last uploaded SARIF per repo.
+var (
+	sarifHashMu  sync.Mutex
+	sarifHashMap = make(map[string]string) // "owner/repo" -> SHA-256 hex
 )
 
 // generateSARIF runs all configured checks at once and writes the results
@@ -76,7 +85,7 @@ func generateSARIF(
 
 	opts := &options.Options{}
 
-	return result.AsSARIF(true, log.DefaultLevel, writer, checkDocs, policy, opts)
+	return result.AsSARIF(true, sclog.DefaultLevel, writer, checkDocs, policy, opts)
 }
 
 // buildPolicy constructs a ScorecardPolicy from Allstar's check names and
@@ -175,4 +184,64 @@ func compressAndEncode(data []byte) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// uploadSARIF generates SARIF for the configured checks and uploads
+// it to GitHub's Code Scanning API, skipping the upload if the SARIF content
+// has not changed since the last upload.
+func uploadSARIF(
+	ctx context.Context,
+	c *github.Client,
+	owner, repo string,
+	checkNames []string,
+	threshold int,
+	scRepo clients.Repo,
+	scRepoClient clients.RepoClient,
+) error {
+	var buf bytes.Buffer
+	if err := generateSARIF(ctx, scRepo, scRepoClient, checkNames, threshold, &buf); err != nil {
+		return fmt.Errorf("generating SARIF: %w", err)
+	}
+
+	sarifBytes := buf.Bytes()
+
+	// Change detection: skip upload if SARIF is unchanged.
+	hash := fmt.Sprintf("%x", sha256.Sum256(sarifBytes))
+	repoKey := fmt.Sprintf("%s/%s", owner, repo)
+
+	sarifHashMu.Lock()
+	lastHash := sarifHashMap[repoKey]
+	sarifHashMu.Unlock()
+
+	if hash == lastHash {
+		log.Debug().
+			Str("org", owner).
+			Str("repo", repo).
+			Str("area", polName).
+			Msg("SARIF unchanged, skipping upload.")
+		return nil
+	}
+
+	if err := uploadToCodeScanning(ctx, c, owner, repo, sarifBytes); err != nil {
+		return err
+	}
+
+	sarifHashMu.Lock()
+	sarifHashMap[repoKey] = hash
+	sarifHashMu.Unlock()
+
+	log.Info().
+		Str("org", owner).
+		Str("repo", repo).
+		Str("area", polName).
+		Msg("SARIF uploaded to Code Scanning.")
+
+	return nil
+}
+
+// clearSARIFHashes resets the change detection state. Exported for testing.
+func clearSARIFHashes() {
+	sarifHashMu.Lock()
+	sarifHashMap = make(map[string]string)
+	sarifHashMu.Unlock()
 }

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -48,7 +47,7 @@ var (
 )
 
 // generateSARIF runs all configured checks at once and writes the results
-// as SARIF 2.1.0 to the provided writer.
+// as SARIF to the provided writer.
 //
 // This is the "dual execution" path: the main Check() method runs checks
 // individually for issue text, while this function runs them together to
@@ -74,10 +73,19 @@ func generateSARIF(
 		return fmt.Errorf("scorecard run for SARIF: %w", err)
 	}
 
-	// Build a ScorecardPolicy from Allstar's checks + threshold config.
+	return resultToSARIF(&result, checkNames, threshold, writer)
+}
+
+// resultToSARIF converts a scorecard Result to SARIF and writes it
+// to the provided writer.
+func resultToSARIF(
+	result *sc.Result,
+	checkNames []string,
+	threshold int,
+	writer io.Writer,
+) error {
 	policy := buildPolicy(checkNames, threshold)
 
-	// Get check documentation for SARIF remediation guidance.
 	checkDocs, err := docs.Read()
 	if err != nil {
 		return fmt.Errorf("reading check docs: %w", err)
@@ -118,13 +126,25 @@ func uploadToCodeScanning(
 		return fmt.Errorf("getting branch info: %w", err)
 	}
 
+	return uploadToCodeScanningWithRef(ctx, c, owner, repo, ref, sha, sarifContent)
+}
+
+// uploadToCodeScanningWithRef uploads SARIF content to GitHub's Code Scanning
+// API using a pre-fetched ref and commit SHA.
+func uploadToCodeScanningWithRef(
+	ctx context.Context,
+	c *github.Client,
+	owner, repo string,
+	ref, commitSHA string,
+	sarifContent []byte,
+) error {
 	encoded, err := compressAndEncode(sarifContent)
 	if err != nil {
 		return fmt.Errorf("compressing SARIF: %w", err)
 	}
 
 	analysis := &github.SarifAnalysis{
-		CommitSHA: github.Ptr(sha),
+		CommitSHA: github.Ptr(commitSHA),
 		Ref:       github.Ptr(ref),
 		Sarif:     github.Ptr(encoded),
 		ToolName:  github.Ptr("OpenSSF Scorecard"),
@@ -198,22 +218,21 @@ func uploadSARIF(
 	scRepo clients.Repo,
 	scRepoClient clients.RepoClient,
 ) error {
-	var buf bytes.Buffer
-	if err := generateSARIF(ctx, scRepo, scRepoClient, checkNames, threshold, &buf); err != nil {
-		return fmt.Errorf("generating SARIF: %w", err)
+	// Change detection: skip upload if the repo HEAD hasn't changed
+	// since the last upload. This avoids redundant uploads when Allstar
+	// runs on a 5-minute cycle and the repo hasn't been updated.
+	ref, commitSHA, err := getDefaultBranchRefFunc(ctx, c, owner, repo)
+	if err != nil {
+		return fmt.Errorf("getting branch info: %w", err)
 	}
 
-	sarifBytes := buf.Bytes()
-
-	// Change detection: skip upload if SARIF is unchanged.
-	hash := fmt.Sprintf("%x", sha256.Sum256(sarifBytes))
 	repoKey := fmt.Sprintf("%s/%s", owner, repo)
 
 	sarifHashMu.Lock()
-	lastHash := sarifHashMap[repoKey]
+	lastSHA := sarifHashMap[repoKey]
 	sarifHashMu.Unlock()
 
-	if hash == lastHash {
+	if commitSHA == lastSHA {
 		log.Debug().
 			Str("org", owner).
 			Str("repo", repo).
@@ -222,12 +241,31 @@ func uploadSARIF(
 		return nil
 	}
 
-	if err := uploadToCodeScanning(ctx, c, owner, repo, sarifBytes); err != nil {
+	// Run all checks at once to get a complete Result.
+	runOpts := []sc.Option{
+		sc.WithChecks(checkNames),
+	}
+	if scRepoClient != nil {
+		runOpts = append(runOpts, sc.WithRepoClient(scRepoClient))
+	}
+
+	result, err := scRun(ctx, scRepo, runOpts...)
+	if err != nil {
+		return fmt.Errorf("scorecard run for SARIF: %w", err)
+	}
+
+	// Generate SARIF from the result.
+	var buf bytes.Buffer
+	if err := resultToSARIF(&result, checkNames, threshold, &buf); err != nil {
+		return fmt.Errorf("generating SARIF: %w", err)
+	}
+
+	if err := uploadToCodeScanningWithRef(ctx, c, owner, repo, ref, commitSHA, buf.Bytes()); err != nil {
 		return err
 	}
 
 	sarifHashMu.Lock()
-	sarifHashMap[repoKey] = hash
+	sarifHashMap[repoKey] = commitSHA
 	sarifHashMu.Unlock()
 
 	log.Info().
@@ -238,6 +276,7 @@ func uploadSARIF(
 
 	return nil
 }
+
 
 // clearSARIFHashes resets the change detection state. Exported for testing.
 func clearSARIFHashes() {

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -1,0 +1,86 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ossf/scorecard/v5/clients"
+	docs "github.com/ossf/scorecard/v5/docs/checks"
+	"github.com/ossf/scorecard/v5/log"
+	"github.com/ossf/scorecard/v5/options"
+	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
+	spol "github.com/ossf/scorecard/v5/policy"
+)
+
+// generateSARIF runs all configured checks at once and writes the results
+// as SARIF 2.1.0 to the provided writer.
+//
+// This is the "dual execution" path: the main Check() method runs checks
+// individually for issue text, while this function runs them together to
+// produce a complete SARIF document.
+func generateSARIF(
+	ctx context.Context,
+	repo clients.Repo,
+	repoClient clients.RepoClient,
+	checkNames []string,
+	threshold int,
+	writer io.Writer,
+) error {
+	// Run all checks at once to get a complete Result.
+	runOpts := []sc.Option{
+		sc.WithChecks(checkNames),
+	}
+	if repoClient != nil {
+		runOpts = append(runOpts, sc.WithRepoClient(repoClient))
+	}
+
+	result, err := scRun(ctx, repo, runOpts...)
+	if err != nil {
+		return fmt.Errorf("scorecard run for SARIF: %w", err)
+	}
+
+	// Build a ScorecardPolicy from Allstar's checks + threshold config.
+	policy := buildPolicy(checkNames, threshold)
+
+	// Get check documentation for SARIF remediation guidance.
+	checkDocs, err := docs.Read()
+	if err != nil {
+		return fmt.Errorf("reading check docs: %w", err)
+	}
+
+	opts := &options.Options{}
+
+	return result.AsSARIF(true, log.DefaultLevel, writer, checkDocs, policy, opts)
+}
+
+// buildPolicy constructs a ScorecardPolicy from Allstar's check names and
+// threshold. Each configured check is marked as enforced with the threshold
+// as its minimum score.
+func buildPolicy(checkNames []string, threshold int) *spol.ScorecardPolicy {
+	policy := &spol.ScorecardPolicy{
+		Version:  1,
+		Policies: make(map[string]*spol.CheckPolicy, len(checkNames)),
+	}
+	for _, name := range checkNames {
+		policy.Policies[name] = &spol.CheckPolicy{
+			Score: int32(threshold),
+			Mode:  spol.CheckPolicy_ENFORCED,
+		}
+	}
+	return policy
+}

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -277,7 +277,6 @@ func uploadSARIF(
 	return nil
 }
 
-
 // clearSARIFHashes resets the change detection state. Exported for testing.
 func clearSARIFHashes() {
 	sarifHashMu.Lock()

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -15,9 +15,14 @@
 package scorecard
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
+
+	"github.com/google/go-github/v74/github"
 
 	"github.com/ossf/scorecard/v5/clients"
 	docs "github.com/ossf/scorecard/v5/docs/checks"
@@ -25,6 +30,12 @@ import (
 	"github.com/ossf/scorecard/v5/options"
 	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
 	spol "github.com/ossf/scorecard/v5/policy"
+)
+
+// Mockable function variables for testing.
+var (
+	codeScanningUploadFunc = codeScanningUploadReal
+	getDefaultBranchRefFunc = getDefaultBranchRefReal
 )
 
 // generateSARIF runs all configured checks at once and writes the results
@@ -83,4 +94,85 @@ func buildPolicy(checkNames []string, threshold int) *spol.ScorecardPolicy {
 		}
 	}
 	return policy
+}
+
+// uploadToCodeScanning uploads SARIF content to GitHub's Code Scanning API
+// for the given repository.
+func uploadToCodeScanning(
+	ctx context.Context,
+	c *github.Client,
+	owner, repo string,
+	sarifContent []byte,
+) error {
+	ref, sha, err := getDefaultBranchRefFunc(ctx, c, owner, repo)
+	if err != nil {
+		return fmt.Errorf("getting branch info: %w", err)
+	}
+
+	encoded, err := compressAndEncode(sarifContent)
+	if err != nil {
+		return fmt.Errorf("compressing SARIF: %w", err)
+	}
+
+	analysis := &github.SarifAnalysis{
+		CommitSHA: github.Ptr(sha),
+		Ref:       github.Ptr(ref),
+		Sarif:     github.Ptr(encoded),
+		ToolName:  github.Ptr("OpenSSF Scorecard"),
+	}
+
+	_, _, err = codeScanningUploadFunc(ctx, c, owner, repo, analysis)
+	if err != nil {
+		return fmt.Errorf("uploading SARIF: %w", err)
+	}
+	return nil
+}
+
+func codeScanningUploadReal(
+	ctx context.Context,
+	c *github.Client,
+	owner, repo string,
+	analysis *github.SarifAnalysis,
+) (*github.SarifID, *github.Response, error) {
+	return c.CodeScanning.UploadSarif(ctx, owner, repo, analysis)
+}
+
+// getDefaultBranchRefReal gets the default branch ref and HEAD commit SHA
+// for a repository.
+func getDefaultBranchRefReal(
+	ctx context.Context,
+	c *github.Client,
+	owner, repo string,
+) (ref, sha string, err error) {
+	r, _, err := c.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return "", "", fmt.Errorf("getting repo: %w", err)
+	}
+	branch := r.GetDefaultBranch()
+	if branch == "" {
+		branch = "main"
+	}
+
+	b, _, err := c.Repositories.GetBranch(ctx, owner, repo, branch, 0)
+	if err != nil {
+		return "", "", fmt.Errorf("getting branch %s: %w", branch, err)
+	}
+
+	return fmt.Sprintf("refs/heads/%s", branch), b.GetCommit().GetSHA(), nil
+}
+
+// compressAndEncode gzip-compresses data and returns it as a base64-encoded
+// string. This is the format required by the GitHub Code Scanning API.
+func compressAndEncode(data []byte) (string, error) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+
+	if _, err := writer.Write(data); err != nil {
+		return "", err
+	}
+	if err := writer.Close(); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }

--- a/pkg/policies/scorecard/sarif_test.go
+++ b/pkg/policies/scorecard/sarif_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+	sc "github.com/ossf/scorecard/v5/pkg/scorecard"
+)
+
+func TestGenerateSARIF(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Checks    []string
+		Threshold int
+		Result    sc.Result
+		WantErr   bool
+	}{
+		{
+			Name:      "BasicGeneration",
+			Checks:    []string{"Binary-Artifacts"},
+			Threshold: 8,
+			Result: sc.Result{
+				Repo: sc.RepoInfo{
+					Name: "github.com/test/repo",
+				},
+				Checks: []checker.CheckResult{
+					{
+						Name:  "Binary-Artifacts",
+						Score: 10,
+					},
+				},
+			},
+			WantErr: false,
+		},
+		{
+			Name:      "MultipleChecks",
+			Checks:    []string{"Binary-Artifacts", "Signed-Releases"},
+			Threshold: 5,
+			Result: sc.Result{
+				Repo: sc.RepoInfo{
+					Name: "github.com/test/repo",
+				},
+				Checks: []checker.CheckResult{
+					{
+						Name:  "Binary-Artifacts",
+						Score: 10,
+					},
+					{
+						Name:  "Signed-Releases",
+						Score: 3,
+					},
+				},
+			},
+			WantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Mock scRun to return our test result
+			origScRun := scRun
+			t.Cleanup(func() { scRun = origScRun })
+			scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+				return test.Result, nil
+			}
+
+			var buf bytes.Buffer
+			err := generateSARIF(
+				context.Background(),
+				nil, // ScClient.ScRepo not needed with mocked scRun
+				nil, // ScClient.ScRepoClient not needed with mocked scRun
+				test.Checks,
+				test.Threshold,
+				&buf,
+			)
+
+			if test.WantErr && err != nil {
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			output := buf.String()
+			if len(output) == 0 {
+				t.Fatal("Expected non-empty SARIF output")
+			}
+
+			// SARIF output should be valid JSON containing the schema URL
+			if !bytes.Contains(buf.Bytes(), []byte("sarif")) {
+				t.Error("Output does not appear to be SARIF format")
+			}
+		})
+	}
+}
+
+func TestGenerateSARIFRunError(t *testing.T) {
+	origScRun := scRun
+	t.Cleanup(func() { scRun = origScRun })
+	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+		return sc.Result{}, errTest
+	}
+
+	var buf bytes.Buffer
+	err := generateSARIF(
+		context.Background(),
+		nil,
+		nil,
+		[]string{"Binary-Artifacts"},
+		8,
+		&buf,
+	)
+	if err == nil {
+		t.Fatal("Expected error from failed scorecard run")
+	}
+}
+
+// errTest is a sentinel error for testing.
+var errTest = errors.New("test error")

--- a/pkg/policies/scorecard/sarif_test.go
+++ b/pkg/policies/scorecard/sarif_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -311,7 +312,7 @@ func TestUploadSARIF(t *testing.T) {
 	}
 }
 
-func TestUploadSARIFDifferentResult(t *testing.T) {
+func TestUploadSARIFNewCommit(t *testing.T) {
 	origScRun := scRun
 	origUpload := codeScanningUploadFunc
 	origGetRef := getDefaultBranchRefFunc
@@ -322,20 +323,22 @@ func TestUploadSARIFDifferentResult(t *testing.T) {
 		clearSARIFHashes()
 	})
 
-	callNum := 0
 	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
-		callNum++
 		return sc.Result{
 			Repo: sc.RepoInfo{Name: "github.com/test/repo"},
 			Checks: []checker.CheckResult{
-				{Name: "Binary-Artifacts", Score: callNum}, // different score each call
+				{Name: "Binary-Artifacts", Score: 10},
 			},
 		}, nil
 	}
+
+	callNum := 0
 	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
 		_, _ string,
 	) (ref, sha string, err error) {
-		return "refs/heads/main", "abc123", nil
+		callNum++
+		// Different commit SHA each call — simulates a new push
+		return "refs/heads/main", fmt.Sprintf("sha-%d", callNum), nil
 	}
 
 	uploadCount := 0
@@ -354,12 +357,12 @@ func TestUploadSARIFDifferentResult(t *testing.T) {
 	if err := uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil); err != nil {
 		t.Fatalf("First upload failed: %v", err)
 	}
-	// Second call should also upload because the result changed.
+	// Second call should also upload because the commit SHA changed.
 	if err := uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil); err != nil {
 		t.Fatalf("Second upload failed: %v", err)
 	}
 	if uploadCount != 2 {
-		t.Errorf("Expected 2 uploads (result changed), got %d", uploadCount)
+		t.Errorf("Expected 2 uploads (new commit), got %d", uploadCount)
 	}
 }
 

--- a/pkg/policies/scorecard/sarif_test.go
+++ b/pkg/policies/scorecard/sarif_test.go
@@ -251,5 +251,113 @@ func TestUploadToCodeScanningAPIError(t *testing.T) {
 	}
 }
 
+func TestUploadSARIF(t *testing.T) {
+	origScRun := scRun
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	t.Cleanup(func() {
+		scRun = origScRun
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+		clearSARIFHashes()
+	})
+
+	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+		return sc.Result{
+			Repo: sc.RepoInfo{Name: "github.com/test/repo"},
+			Checks: []checker.CheckResult{
+				{Name: "Binary-Artifacts", Score: 10},
+			},
+		}, nil
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+
+	uploadCount := 0
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, _ *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		uploadCount++
+		return &github.SarifID{ID: github.Ptr("test-id")}, nil, nil
+	}
+
+	ctx := context.Background()
+	c := github.NewClient(nil)
+	checks := []string{"Binary-Artifacts"}
+
+	// First call should upload.
+	err := uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil)
+	if err != nil {
+		t.Fatalf("First upload failed: %v", err)
+	}
+	if uploadCount != 1 {
+		t.Errorf("Expected 1 upload, got %d", uploadCount)
+	}
+
+	// Second call with same result should skip (change detection).
+	err = uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil)
+	if err != nil {
+		t.Fatalf("Second call failed: %v", err)
+	}
+	if uploadCount != 1 {
+		t.Errorf("Expected still 1 upload (skipped), got %d", uploadCount)
+	}
+}
+
+func TestUploadSARIFDifferentResult(t *testing.T) {
+	origScRun := scRun
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	t.Cleanup(func() {
+		scRun = origScRun
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+		clearSARIFHashes()
+	})
+
+	callNum := 0
+	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+		callNum++
+		return sc.Result{
+			Repo: sc.RepoInfo{Name: "github.com/test/repo"},
+			Checks: []checker.CheckResult{
+				{Name: "Binary-Artifacts", Score: callNum}, // different score each call
+			},
+		}, nil
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+
+	uploadCount := 0
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, _ *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		uploadCount++
+		return &github.SarifID{ID: github.Ptr("test-id")}, nil, nil
+	}
+
+	ctx := context.Background()
+	c := github.NewClient(nil)
+	checks := []string{"Binary-Artifacts"}
+
+	// First call uploads.
+	if err := uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil); err != nil {
+		t.Fatalf("First upload failed: %v", err)
+	}
+	// Second call should also upload because the result changed.
+	if err := uploadSARIF(ctx, c, "testorg", "testrepo", checks, 8, nil, nil); err != nil {
+		t.Fatalf("Second upload failed: %v", err)
+	}
+	if uploadCount != 2 {
+		t.Errorf("Expected 2 uploads (result changed), got %d", uploadCount)
+	}
+}
+
 // errTest is a sentinel error for testing.
 var errTest = errors.New("test error")

--- a/pkg/policies/scorecard/sarif_test.go
+++ b/pkg/policies/scorecard/sarif_test.go
@@ -16,9 +16,14 @@ package scorecard
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"errors"
+	"io"
 	"testing"
+
+	"github.com/google/go-github/v74/github"
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/clients"
@@ -130,6 +135,119 @@ func TestGenerateSARIFRunError(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("Expected error from failed scorecard run")
+	}
+}
+
+func TestCompressAndEncode(t *testing.T) {
+	input := []byte(`{"version":"2.1.0","runs":[]}`)
+
+	encoded, err := compressAndEncode(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(encoded) == 0 {
+		t.Fatal("Expected non-empty encoded output")
+	}
+
+	// Decode base64
+	compressed, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("Invalid base64: %v", err)
+	}
+
+	// Decompress gzip
+	reader, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("Invalid gzip: %v", err)
+	}
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Failed to read gzip: %v", err)
+	}
+
+	if !bytes.Equal(decompressed, input) {
+		t.Errorf("Round-trip failed. want %q, got %q", input, decompressed)
+	}
+}
+
+func TestUploadToCodeScanning(t *testing.T) {
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	t.Cleanup(func() {
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+	})
+
+	var capturedAnalysis *github.SarifAnalysis
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, analysis *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		capturedAnalysis = analysis
+		return &github.SarifID{ID: github.Ptr("test-id")}, nil, nil
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+
+	sarifContent := []byte(`{"version":"2.1.0","runs":[]}`)
+	err := uploadToCodeScanning(
+		context.Background(),
+		github.NewClient(nil),
+		"testorg", "testrepo",
+		sarifContent,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if capturedAnalysis == nil {
+		t.Fatal("Expected upload to be called")
+	}
+	if capturedAnalysis.GetCommitSHA() != "abc123" {
+		t.Errorf("Expected commit SHA abc123, got %s", capturedAnalysis.GetCommitSHA())
+	}
+	if capturedAnalysis.GetRef() != "refs/heads/main" {
+		t.Errorf("Expected ref refs/heads/main, got %s", capturedAnalysis.GetRef())
+	}
+	if capturedAnalysis.GetToolName() != "OpenSSF Scorecard" {
+		t.Errorf("Expected tool name OpenSSF Scorecard, got %s", capturedAnalysis.GetToolName())
+	}
+	if capturedAnalysis.GetSarif() == "" {
+		t.Error("Expected non-empty SARIF content")
+	}
+}
+
+func TestUploadToCodeScanningAPIError(t *testing.T) {
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	t.Cleanup(func() {
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+	})
+
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, _ *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		return nil, nil, errTest
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+
+	err := uploadToCodeScanning(
+		context.Background(),
+		github.NewClient(nil),
+		"testorg", "testrepo",
+		[]byte(`{}`),
+	)
+	if err == nil {
+		t.Fatal("Expected error from failed API call")
 	}
 }
 

--- a/pkg/policies/scorecard/sarif_test.go
+++ b/pkg/policies/scorecard/sarif_test.go
@@ -21,9 +21,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-github/v74/github"
+
+	"github.com/ossf/allstar/pkg/config"
+	"github.com/ossf/allstar/pkg/scorecard"
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/clients"
@@ -356,6 +360,182 @@ func TestUploadSARIFDifferentResult(t *testing.T) {
 	}
 	if uploadCount != 2 {
 		t.Errorf("Expected 2 uploads (result changed), got %d", uploadCount)
+	}
+}
+
+func TestCheckWithSARIFUpload(t *testing.T) {
+	origScRun := scRun
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	origFetch := configFetchConfig
+	origEnabled := configIsEnabled
+	origGet := scorecardGet
+	origChecks := checksAllChecks
+	t.Cleanup(func() {
+		scRun = origScRun
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+		configFetchConfig = origFetch
+		configIsEnabled = origEnabled
+		scorecardGet = origGet
+		checksAllChecks = origChecks
+		clearSARIFHashes()
+	})
+
+	uploadCount := 0
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, _ *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		uploadCount++
+		return &github.SarifID{ID: github.Ptr("test-id")}, nil, nil
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+	configIsEnabled = func(_ context.Context, _ config.OrgOptConfig, _,
+		_ config.RepoOptConfig, _ *github.Client, _, _ string,
+	) (bool, error) {
+		return true, nil
+	}
+	scorecardGet = func(_ context.Context, _ string, _ bool,
+		_ http.RoundTripper,
+	) (*scorecard.ScClient, error) {
+		return &scorecard.ScClient{}, nil
+	}
+	checksAllChecks = checker.CheckNameToFnMap{"Binary-Artifacts": {}}
+	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+		return sc.Result{
+			Repo:   sc.RepoInfo{Name: "github.com/test/repo"},
+			Checks: []checker.CheckResult{{Name: "Binary-Artifacts", Score: 10}},
+		}, nil
+	}
+
+	tests := []struct {
+		Name         string
+		Upload       UploadConfig
+		ExpectUpload bool
+	}{
+		{
+			Name:         "UploadEnabled",
+			Upload:       UploadConfig{SARIF: true},
+			ExpectUpload: true,
+		},
+		{
+			Name:         "UploadDisabled",
+			Upload:       UploadConfig{SARIF: false},
+			ExpectUpload: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			uploadCount = 0
+			clearSARIFHashes()
+
+			configFetchConfig = func(_ context.Context, _ *github.Client,
+				_, _, _ string, ol config.ConfigLevel, out interface{},
+			) error {
+				if ol == config.OrgLevel {
+					oc := out.(*OrgConfig)
+					*oc = OrgConfig{
+						Action:    "issue",
+						Checks:    []string{"Binary-Artifacts"},
+						Threshold: 8,
+						Upload:    test.Upload,
+					}
+				}
+				return nil
+			}
+
+			s := NewScorecard()
+			res, err := s.Check(context.Background(), github.NewClient(nil), "testorg", "testrepo")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !res.Pass {
+				t.Error("Expected pass")
+			}
+			if test.ExpectUpload && uploadCount == 0 {
+				t.Error("Expected SARIF upload but none occurred")
+			}
+			if !test.ExpectUpload && uploadCount > 0 {
+				t.Errorf("Expected no SARIF upload but got %d", uploadCount)
+			}
+		})
+	}
+}
+
+func TestCheckSARIFUploadErrorNonBlocking(t *testing.T) {
+	origScRun := scRun
+	origUpload := codeScanningUploadFunc
+	origGetRef := getDefaultBranchRefFunc
+	origFetch := configFetchConfig
+	origEnabled := configIsEnabled
+	origGet := scorecardGet
+	origChecks := checksAllChecks
+	t.Cleanup(func() {
+		scRun = origScRun
+		codeScanningUploadFunc = origUpload
+		getDefaultBranchRefFunc = origGetRef
+		configFetchConfig = origFetch
+		configIsEnabled = origEnabled
+		scorecardGet = origGet
+		checksAllChecks = origChecks
+		clearSARIFHashes()
+	})
+
+	codeScanningUploadFunc = func(_ context.Context, _ *github.Client,
+		_, _ string, _ *github.SarifAnalysis,
+	) (*github.SarifID, *github.Response, error) {
+		return nil, nil, errTest
+	}
+	getDefaultBranchRefFunc = func(_ context.Context, _ *github.Client,
+		_, _ string,
+	) (ref, sha string, err error) {
+		return "refs/heads/main", "abc123", nil
+	}
+	configFetchConfig = func(_ context.Context, _ *github.Client,
+		_, _, _ string, ol config.ConfigLevel, out interface{},
+	) error {
+		if ol == config.OrgLevel {
+			oc := out.(*OrgConfig)
+			*oc = OrgConfig{
+				Action:    "issue",
+				Checks:    []string{"Binary-Artifacts"},
+				Threshold: 8,
+				Upload:    UploadConfig{SARIF: true},
+			}
+		}
+		return nil
+	}
+	configIsEnabled = func(_ context.Context, _ config.OrgOptConfig, _,
+		_ config.RepoOptConfig, _ *github.Client, _, _ string,
+	) (bool, error) {
+		return true, nil
+	}
+	scorecardGet = func(_ context.Context, _ string, _ bool,
+		_ http.RoundTripper,
+	) (*scorecard.ScClient, error) {
+		return &scorecard.ScClient{}, nil
+	}
+	checksAllChecks = checker.CheckNameToFnMap{"Binary-Artifacts": {}}
+	scRun = func(_ context.Context, _ clients.Repo, _ ...sc.Option) (sc.Result, error) {
+		return sc.Result{
+			Repo:   sc.RepoInfo{Name: "github.com/test/repo"},
+			Checks: []checker.CheckResult{{Name: "Binary-Artifacts", Score: 10}},
+		}, nil
+	}
+
+	s := NewScorecard()
+	res, err := s.Check(context.Background(), github.NewClient(nil), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	// Upload failed, but Check() should still pass — non-blocking.
+	if !res.Pass {
+		t.Error("Expected pass despite SARIF upload failure")
 	}
 }
 

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -38,6 +38,13 @@ const (
 	polName    = "OpenSSF Scorecard"
 )
 
+// UploadConfig configures evidence upload for the Scorecard policy.
+type UploadConfig struct {
+	// SARIF enables uploading SARIF results to GitHub's Code Scanning API.
+	// Requires the GitHub App to have security_events: write permission.
+	SARIF bool `json:"sarif"`
+}
+
 // OrgConfig is the org-level config definition for this policy.
 type OrgConfig struct {
 	// OptConfig is the standard org-level opt in/out config, RepoOverride
@@ -60,6 +67,9 @@ type OrgConfig struct {
 	// policy will pass. The default is checker.MaxResultScore:
 	// https://pkg.go.dev/github.com/ossf/scorecard/v5/checker#pkg-constants
 	Threshold int `json:"threshold"`
+
+	// Upload configures evidence upload. See UploadConfig for details.
+	Upload UploadConfig `json:"upload"`
 }
 
 // RepoConfig is the repo-level config for this policy.
@@ -75,12 +85,16 @@ type RepoConfig struct {
 
 	// Threshold overrides the same setting in org-level, only if present.
 	Threshold *int `json:"threshold"`
+
+	// Upload overrides the same setting in org-level, only if present.
+	Upload *UploadConfig `json:"upload,omitempty"`
 }
 
 type mergedConfig struct {
 	Action    string
 	Checks    []string
 	Threshold int
+	Upload    UploadConfig
 }
 
 type details struct {
@@ -336,6 +350,7 @@ func mergeConfig(oc *OrgConfig, orc, rc *RepoConfig, repo string) *mergedConfig 
 		Action:    oc.Action,
 		Checks:    oc.Checks,
 		Threshold: oc.Threshold,
+		Upload:    oc.Upload,
 	}
 	mc = mergeInRepoConfig(mc, orc, repo)
 
@@ -354,6 +369,9 @@ func mergeInRepoConfig(mc *mergedConfig, rc *RepoConfig, repo string) *mergedCon
 	}
 	if rc.Threshold != nil {
 		mc.Threshold = *rc.Threshold
+	}
+	if rc.Upload != nil {
+		mc.Upload = *rc.Upload
 	}
 	return mc
 }

--- a/pkg/policies/scorecard/scorecard.go
+++ b/pkg/policies/scorecard/scorecard.go
@@ -252,6 +252,18 @@ The score was %v, and the passing threshold is %v.
 		}
 	}
 
+	if mc.Upload.SARIF {
+		if err := uploadSARIF(ctx, c, owner, repo, mc.Checks, mc.Threshold,
+			scc.ScRepo, scc.ScRepoClient); err != nil {
+			log.Warn().
+				Str("org", owner).
+				Str("repo", repo).
+				Str("area", polName).
+				Err(err).
+				Msg("SARIF upload failed, continuing.")
+		}
+	}
+
 	return &policydef.Result{
 		Enabled:    enabled,
 		Pass:       pass,

--- a/pkg/policies/scorecard/scorecard_test.go
+++ b/pkg/policies/scorecard/scorecard_test.go
@@ -100,6 +100,83 @@ func TestConfigPrecedence(t *testing.T) {
 				Action: "log",
 			},
 		},
+		{
+			Name: "UploadDefaultDisabled",
+			Org: OrgConfig{
+				Action: "issue",
+			},
+			OrgRepo:   RepoConfig{},
+			Repo:      RepoConfig{},
+			ExpAction: "issue",
+			Exp: mergedConfig{
+				Action: "issue",
+			},
+		},
+		{
+			Name: "UploadEnabledAtOrg",
+			Org: OrgConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: true},
+			},
+			OrgRepo:   RepoConfig{},
+			Repo:      RepoConfig{},
+			ExpAction: "issue",
+			Exp: mergedConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: true},
+			},
+		},
+		{
+			Name: "UploadOrgRepoOverridesOrg",
+			Org: OrgConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: true},
+			},
+			OrgRepo: RepoConfig{
+				Upload: &UploadConfig{SARIF: false},
+			},
+			Repo:      RepoConfig{},
+			ExpAction: "issue",
+			Exp: mergedConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: false},
+			},
+		},
+		{
+			Name: "UploadRepoOverridesAll",
+			Org: OrgConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: false},
+			},
+			OrgRepo: RepoConfig{},
+			Repo: RepoConfig{
+				Upload: &UploadConfig{SARIF: true},
+			},
+			ExpAction: "issue",
+			Exp: mergedConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: true},
+			},
+		},
+		{
+			Name: "UploadRepoDisallowed",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					DisableRepoOverride: true,
+				},
+				Action: "issue",
+				Upload: UploadConfig{SARIF: false},
+			},
+			OrgRepo: RepoConfig{},
+			Repo: RepoConfig{
+				Upload: &UploadConfig{SARIF: true},
+			},
+			ExpAction: "issue",
+			Exp: mergedConfig{
+				Action: "issue",
+				Upload: UploadConfig{SARIF: false},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

- Add evidence upload capability to the Scorecard policy, starting with SARIF upload to GitHub's Code Scanning API
- Enable org admins to get Scorecard findings in each repo's **Security > Code Scanning** tab without per-repo workflow setup
- Bootstrap `openspec/` directory in Allstar for spec-driven development

## Motivation

Organizations using Allstar's Scorecard policy get violation notifications via GitHub issues, but findings do not appear in the GitHub Security tab. This creates a gap for:

- **Org admins** who want centralized security visibility across all repositories
- **Security teams** who want findings alongside CodeQL, Dependabot, and other tools in the standard Security dashboard
- **Compliance workflows** that require evidence in the Security tab for audit purposes

## Design decisions

Full design rationale in `openspec/changes/evidence-upload/design.md`. Key decisions:

- **Config model:** `upload: {sarif: true}` on `scorecard.yaml` — extensible for v6 evidence formats (in-toto, OSCAL, Gemara)
- **Execution model:** Dual execution — keeps per-check loop for issue text, adds full `sc.Run()` for SARIF generation
- **Upload:** Uses `go-github/v74`'s `CodeScanning.UploadSarif()` (Allstar is a standalone app, can't delegate to `upload-sarif` action like scorecard-action)
- **Change detection:** Compares repository HEAD commit SHA — skips scan and upload when the repo hasn't been pushed to since the last upload
- **Error handling:** Non-blocking — upload failures are logged as warnings, don't affect policy check results
- **Permission:** Requires the **Code scanning alerts** repository permission set to **Read & write** (API scope: `security_events`). Self-hosted operators add this; public App update coordinated separately.

## Scorecard v6 alignment

This feature is designed as Phase 1 of a broader evidence upload capability aligned with the [Scorecard v6 direction](https://github.com/ossf/scorecard/pull/4952):

- Allstar acts as an evidence **consumer**, using `Result.AsSARIF()` from scorecard v5.4.0
- The `upload` config struct is extensible for v6 formats without schema changes
- See `openspec/changes/evidence-upload/proposal.md` for ecosystem positioning

## User-facing config

```yaml
# .allstar/scorecard.yaml
optConfig:
  optOutStrategy: true
action: issue
checks:
  - Binary-Artifacts
  - Signed-Releases
threshold: 8
upload:
  sarif: true
```

## Test plan

- [x] Config merge tests: upload set at org/orgRepo/repo levels, override semantics, `DisableRepoOverride`
- [x] SARIF generation tests: single check, multiple checks, scorecard run errors
- [x] Compression tests: gzip + base64 round-trip
- [x] Upload tests: correct SarifAnalysis fields, API error propagation
- [x] Change detection tests: skip on same commit SHA, upload on new commit SHA
- [x] Integration tests: `Check()` with upload enabled/disabled, non-blocking error handling
- [x] Manual: self-hosted operator with `Code scanning alerts: Read & write` permission
- [x] Manual: change detection verified in continuous mode (skip on second cycle)

### Manual test results

Tested with a self-hosted Allstar instance (built from this branch) against a GitHub org with `upload: {sarif: true}` configured in the Scorecard policy.

**Setup:**

- Created a GitHub App with **Code scanning alerts: Read & write** permission
- Installed the App on the test org
- Built Allstar locally from the `evidence-upload` branch

**SARIF upload** (`-once` mode):

```json
{"severity":"INFO","org":"<redacted>","repo":"<redacted>",
 "area":"OpenSSF Scorecard",
 "message":"SARIF uploaded to Code Scanning."}
```

Confirmed via the Code Scanning analyses API:

```
2026-03-22T15:40:59Z  Scorecard  v0.0.0-20260322064744-3b263976b3f8+dirty  6 results
2026-03-22T15:40:59Z  Scorecard  v0.0.0-20260322064744-3b263976b3f8+dirty  2 results
2026-03-22T15:40:59Z  Scorecard  v0.0.0-20260322064744-3b263976b3f8+dirty  1 results
```

The `+dirty` version suffix and today's timestamp confirm results came from the local build, not a previous scorecard-action workflow run.

**Change detection** (continuous mode):

```
First cycle:  {"severity":"INFO",...,"message":"SARIF uploaded to Code Scanning."}
Second cycle: {"severity":"DEBUG",...,"message":"SARIF unchanged, skipping upload."}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)