### PR TITLE
build: update Go from 1.24.6 to 1.25.8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,8 @@
 steps:
-- name: golang:1.24
+- name: golang:1.25
   entrypoint: go
   args: ['install', 'github.com/google/ko@v0.18.0']
-- name: golang:1.24
+- name: golang:1.25
   entrypoint: bash
   args: ['-c', 'KO_DOCKER_REPO="gcr.io/allstar-ossf" /go/bin/ko publish ./cmd/allstar > container']
 - name: gcr.io/google.com/cloudsdktool/cloud-sdk

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/allstar
 
-go 1.24.6
+go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- Update `go` directive in `go.mod` from 1.24.6 to 1.25.8
- Update `golang` Docker image in `cloudbuild.yaml` from 1.24 to 1.25

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go mod tidy` — no changes needed

Co-Authored-By: Claude <noreply@anthropic.com>