### PR TITLE
scorecard: Add results file output for `scorecard-monitor` integration

### DIFF
--- a/cmd/allstar/main.go
+++ b/cmd/allstar/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ossf/allstar/pkg/enforce"
 	"github.com/ossf/allstar/pkg/ghclients"
 	"github.com/ossf/allstar/pkg/policies"
+	scorecardPolicy "github.com/ossf/allstar/pkg/policies/scorecard"
 )
 
 func main() {
@@ -61,6 +62,7 @@ func main() {
 
 	specificPolicyArg := flag.String("policy", "", fmt.Sprintf("Run a specific policy check. Supported policies: %s", supportedPoliciesMsg))
 	specificRepoArg := flag.String("repo", "", "Run on a specific \"owner/repo\". For example \"ossf/allstar\"")
+	resultsFileArg := flag.String("results-file", "", "Write Scorecard results to this file as JSON (Scorecard JSON v2 format).")
 
 	flag.Parse()
 
@@ -86,6 +88,13 @@ func main() {
 			log.Fatal().
 				Err(err).
 				Msg("Unexpected error enforcing policies.")
+		}
+		if *resultsFileArg != "" {
+			if err := scorecardPolicy.WriteResults(*resultsFileArg); err != nil {
+				log.Error().
+					Err(err).
+					Msg("Failed to write results file.")
+			}
 		}
 	} else {
 		var wg sync.WaitGroup

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -48,8 +48,7 @@ var (
 	sarifHashMap = make(map[string]string) // "owner/repo" -> commit SHA
 )
 
-// Results collector: accumulates Scorecard JSON v2 results across repos
-// for writing to a results file after the enforcement loop completes.
+// Results collector: accumulates Scorecard results across repos.
 var (
 	resultsMu      sync.Mutex
 	resultsEntries []sc.JSONScorecardResultV2
@@ -289,7 +288,7 @@ func uploadSARIF(
 	return nil
 }
 
-// clearSARIFHashes resets the change detection state. Exported for testing.
+// clearSARIFHashes resets the change detection state.
 func clearSARIFHashes() {
 	sarifHashMu.Lock()
 	sarifHashMap = make(map[string]string)
@@ -323,8 +322,7 @@ func collectResult(result *sc.Result) {
 }
 
 // WriteResults writes all collected Scorecard results to the specified file
-// as a JSON array of Scorecard JSON v2 objects. This is compatible with
-// scorecard-monitor's local-results-path input.
+// as a JSON array of Scorecard JSON v2 objects.
 func WriteResults(path string) error {
 	resultsMu.Lock()
 	entries := make([]sc.JSONScorecardResultV2, len(resultsEntries))
@@ -356,7 +354,7 @@ func WriteResults(path string) error {
 	return nil
 }
 
-// ClearResults resets the results collector. Exported for testing.
+// ClearResults resets the results collector.
 func ClearResults() {
 	resultsMu.Lock()
 	resultsEntries = nil

--- a/pkg/policies/scorecard/sarif.go
+++ b/pkg/policies/scorecard/sarif.go
@@ -19,8 +19,10 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/google/go-github/v74/github"
@@ -40,10 +42,17 @@ var (
 	getDefaultBranchRefFunc = getDefaultBranchRefReal
 )
 
-// Change detection: in-memory hash of last uploaded SARIF per repo.
+// Change detection: in-memory commit SHA of last uploaded SARIF per repo.
 var (
 	sarifHashMu  sync.Mutex
-	sarifHashMap = make(map[string]string) // "owner/repo" -> SHA-256 hex
+	sarifHashMap = make(map[string]string) // "owner/repo" -> commit SHA
+)
+
+// Results collector: accumulates Scorecard JSON v2 results across repos
+// for writing to a results file after the enforcement loop completes.
+var (
+	resultsMu      sync.Mutex
+	resultsEntries []sc.JSONScorecardResultV2
 )
 
 // generateSARIF runs all configured checks at once and writes the results
@@ -254,6 +263,9 @@ func uploadSARIF(
 		return fmt.Errorf("scorecard run for SARIF: %w", err)
 	}
 
+	// Collect JSON v2 result for results file output.
+	collectResult(&result)
+
 	// Generate SARIF from the result.
 	var buf bytes.Buffer
 	if err := resultToSARIF(&result, checkNames, threshold, &buf); err != nil {
@@ -282,4 +294,71 @@ func clearSARIFHashes() {
 	sarifHashMu.Lock()
 	sarifHashMap = make(map[string]string)
 	sarifHashMu.Unlock()
+}
+
+// collectResult stores a Scorecard result for later export via WriteResults.
+func collectResult(result *sc.Result) {
+	checkDocs, err := docs.Read()
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to read check docs for results collection.")
+		return
+	}
+
+	// AsJSON2 writes JSON to a writer; capture it and decode back to struct.
+	var buf bytes.Buffer
+	if err := result.AsJSON2(&buf, checkDocs, nil); err != nil {
+		log.Warn().Err(err).Msg("Failed to convert result to JSON v2.")
+		return
+	}
+
+	var entry sc.JSONScorecardResultV2
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		log.Warn().Err(err).Msg("Failed to parse JSON v2 result.")
+		return
+	}
+
+	resultsMu.Lock()
+	resultsEntries = append(resultsEntries, entry)
+	resultsMu.Unlock()
+}
+
+// WriteResults writes all collected Scorecard results to the specified file
+// as a JSON array of Scorecard JSON v2 objects. This is compatible with
+// scorecard-monitor's local-results-path input.
+func WriteResults(path string) error {
+	resultsMu.Lock()
+	entries := make([]sc.JSONScorecardResultV2, len(resultsEntries))
+	copy(entries, resultsEntries)
+	resultsMu.Unlock()
+
+	if len(entries) == 0 {
+		log.Debug().Msg("No results to write.")
+		return nil
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("creating results file: %w", err)
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(entries); err != nil {
+		return fmt.Errorf("encoding results: %w", err)
+	}
+
+	log.Info().
+		Str("path", path).
+		Int("count", len(entries)).
+		Msg("Scorecard results written to file.")
+
+	return nil
+}
+
+// ClearResults resets the results collector. Exported for testing.
+func ClearResults() {
+	resultsMu.Lock()
+	resultsEntries = nil
+	resultsMu.Unlock()
 }


### PR DESCRIPTION
## Summary

Add a `-results-file` flag that writes Scorecard results in Scorecard JSON v2 format, enabling integration with [scorecard-monitor](https://github.com/ossf/scorecard-monitor) for org-wide dashboard reporting.

## Motivation

After implementing SARIF upload to GitHub Code Scanning (the `evidence-upload` branch), the next integration point is feeding Allstar results into scorecard-monitor for trend tracking and reporting. scorecard-monitor is adding a `results-path` input ([ossf/scorecard-monitor#90](https://github.com/ossf/scorecard-monitor/pull/90)) that can consume Scorecard results from a file instead of querying the public API.

## Design

Uses Scorecard's own `JSONScorecardResultV2` format via `Result.AsJSON2()` — no custom format. This ensures compatibility with scorecard-monitor and any other tool that consumes Scorecard JSON output.

Results are collected at the policy level (scorecard package) using a mutex-protected collector, following the same pattern as `sarifHashMap`. The main binary calls `WriteResults()` after `EnforceAll()` completes.

## Usage

```bash
./allstar -once -results-file /tmp/results.json
```

Output is an array of Scorecard JSON v2 objects — one per scanned repo.

## Related PRs

- [ossf/scorecard-monitor#90](https://github.com/ossf/scorecard-monitor/pull/90) — adds `results-path` input to scorecard-monitor (consuming end)
- Based on the `evidence-upload` branch (SARIF upload feature)

## Test plan

- [x] Build passes
- [x] All existing tests pass (18 tests)
- [x] `go vet` clean
- [x] Single-repo results file output verified
- [x] Multi-repo results file output verified (11 repos, all with valid aggregate scores and checks)
- [x] End-to-end: Allstar produces results.json (11 repos) -> scorecard-monitor consumes it -> valid Markdown report with all repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)