### PR TITLE
feat: recognize rulesets in branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,12 +321,19 @@ here](https://pkg.go.dev/github.com/ossf/allstar/pkg/policies/branch#OrgConfig).
 
 The branch protection policy checks that GitHub's [branch protection
 settings](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
-are setup correctly according to the specified configuration. The issue text
-will describe which setting is incorrect. See [GitHub's
+or active repository rulesets are setup correctly according to the specified
+configuration. The issue text will describe which setting is incorrect. See
+[GitHub's
 documentation](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
 for correcting settings.
 
-The `fix` action will change the branch protection settings to be in compliance with the specified policy configuration.
+Rulesets are checked for requirements that directly map to branch protection
+configuration, such as pull request reviews, required status checks, signed
+commits, and non-fast-forward protection. Rulesets are not used to satisfy
+`enforceOnAdmins`, because rulesets model bypass differently than classic
+branch protection. The `fix` action changes classic branch protection settings
+to be in compliance with the specified policy configuration; it does not create
+or update rulesets.
 
 ### Binary Artifacts
 

--- a/pkg/policies/branch/branch.go
+++ b/pkg/policies/branch/branch.go
@@ -210,6 +210,8 @@ type repositories interface {
 		[]*github.Branch, *github.Response, error)
 	GetBranchProtection(context.Context, string, string, string) (
 		*github.Protection, *github.Response, error)
+	GetRulesForBranch(context.Context, string, string, string, *github.ListOptions) (
+		*github.BranchRules, *github.Response, error)
 	UpdateBranchProtection(context.Context, string, string, string,
 		*github.ProtectionRequest) (*github.Protection, *github.Response, error)
 	GetSignaturesProtectedBranch(ctx context.Context, owner, repo, branch string) (
@@ -298,120 +300,56 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 	ds := make(map[string]details)
 	for _, b := range allBranches {
 		p, rsp, err := rep.GetBranchProtection(ctx, owner, repo, b)
+		var d details
+		protected := true
 		if err != nil {
 			if rsp != nil && rsp.StatusCode == http.StatusNotFound {
-				// Branch not protected
-				pass = false
-				text = text + fmt.Sprintf("No protection found for branch %v\n", b)
-				ds[b] = details{}
-				continue
-			}
-			if rsp != nil && rsp.StatusCode == http.StatusForbidden {
-				// Protection not available
-				pass = false
-				text = text + "Branch Protection enforcement is configured in Allstar, however Branch Protection is not available on this repository. Upgrade to GitHub Pro or make this repository public to enable this feature.\n" +
-					"See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches for more information.\n" +
-					"If this is not feasible, then disable Branch Protection policy enforcement for this repository in Allstar configuration."
-				ds[b] = details{}
-				break
-			}
-			return nil, err
-		}
-
-		var d details
-		rev := p.GetRequiredPullRequestReviews()
-		if rev != nil {
-			d.PRReviews = true
-			d.DismissStale = rev.DismissStaleReviews
-			d.RequireCodeOwnerReviews = rev.RequireCodeOwnerReviews
-			if mc.DismissStale && !rev.DismissStaleReviews {
-				text = text +
-					fmt.Sprintf("Dismiss stale reviews not configured for branch %v\n", b)
-				pass = false
-			}
-			d.NumReviews = rev.RequiredApprovingReviewCount
-			if rev.RequiredApprovingReviewCount < mc.ApprovalCount {
-				pass = false
-				text = text +
-					fmt.Sprintf("PR Approvals below threshold %v : %v for branch %v\n",
-						rev.RequiredApprovingReviewCount, mc.ApprovalCount, b)
-			}
-			if mc.RequireCodeOwnerReviews && !rev.RequireCodeOwnerReviews {
-				text = text +
-					fmt.Sprintf("Require Code Owner Reviews not configured for branch %v\n", b)
-				pass = false
-			}
-		} else {
-			if mc.RequireApproval || mc.RequireCodeOwnerReviews {
-				pass = false
-				text = text +
-					fmt.Sprintf("PR Approvals not configured for branch %v\n", b)
-			}
-		}
-		afp := p.GetAllowForcePushes()
-		d.BlockForce = true
-		if afp != nil {
-			if mc.BlockForce && afp.Enabled {
-				text = text +
-					fmt.Sprintf("Block force push not configured for branch %v\n", b)
-				pass = false
-				d.BlockForce = false
-			}
-		}
-		ea := p.GetEnforceAdmins()
-		d.EnforceOnAdmins = (ea != nil && ea.Enabled)
-		if mc.EnforceOnAdmins && (ea == nil || !ea.Enabled) {
-			text = text +
-				fmt.Sprintf("Enforce status checks on admins not configured for branch %v\n",
-					b)
-			pass = false
-		}
-		if len(mc.RequireStatusChecks) > 0 {
-			rsc := p.GetRequiredStatusChecks()
-			if rsc != nil {
-				d.RequireUpToDateBranch = rsc.Strict
-				if mc.RequireUpToDateBranch && !rsc.Strict {
-					text = text +
-						fmt.Sprintf("Require up to date branch not configured for branch %v\n",
-							b)
-					pass = false
-				}
-				for _, c := range rsc.GetChecks() {
-					sc := StatusCheck{Context: c.Context, AppID: c.AppID}
-					d.RequireStatusChecks = append(d.RequireStatusChecks, sc)
-				}
-				lt := makeSCLookupTable(rsc.GetChecks())
-				for _, c := range mc.RequireStatusChecks {
-					appIDTxt := "(any app)"
-					sch := statusCheckHash{context: c.Context}
-					if c.AppID != nil {
-						sch.appID = *c.AppID
-						appIDTxt = fmt.Sprintf("(AppID: %v)", *c.AppID)
-					}
-					if _, ok := lt[sch]; !ok {
-						text = text +
-							fmt.Sprintf("Status check %s %s not found for branch %v\n",
-								c.Context, appIDTxt, b)
-						pass = false
-					}
-				}
+				// Branch not protected with classic branch protection.
+				protected = false
 			} else {
-				text = text +
-					fmt.Sprintf("Status checks required by policy, but none found for branch %v\n", b)
-				pass = false
+				if rsp != nil && rsp.StatusCode == http.StatusForbidden {
+					// Protection not available
+					pass = false
+					text = text + "Branch Protection enforcement is configured in Allstar, however Branch Protection is not available on this repository. Upgrade to GitHub Pro or make this repository public to enable this feature.\n" +
+						"See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches for more information.\n" +
+						"If this is not feasible, then disable Branch Protection policy enforcement for this repository in Allstar configuration."
+					ds[b] = details{}
+					break
+				}
+				return nil, err
 			}
 		}
 
-		signatureProtectionEnabled, err := getSignatureProtectionEnabled(ctx, rep, owner, repo, b)
-		if err != nil {
-			return nil, err
-		}
-		d.RequireSignedCommits = signatureProtectionEnabled
-		if mc.RequireSignedCommits && !d.RequireSignedCommits {
-			pass = false
-			text = text + fmt.Sprintf("Signed commits required, but not enabled for branch: %v\n", b)
+		if protected {
+			d = getProtectionDetails(p)
 		}
 
+		branchPass, branchText := evaluateBranchDetails(b, d, mc, protected)
+		if !branchPass {
+			rulesetDetails, rulesetProtected, err := getRulesetDetails(ctx, rep, owner, repo, b)
+			if err != nil {
+				return nil, err
+			}
+			if rulesetProtected {
+				d = mergeDetails(d, rulesetDetails)
+				protected = true
+				branchPass, branchText = evaluateBranchDetails(b, d, mc, protected)
+			}
+		}
+
+		if protected && mc.RequireSignedCommits && !d.RequireSignedCommits {
+			signatureProtectionEnabled, err := getSignatureProtectionEnabled(ctx, rep, owner, repo, b)
+			if err != nil {
+				return nil, err
+			}
+			d.RequireSignedCommits = signatureProtectionEnabled
+			branchPass, branchText = evaluateBranchDetails(b, d, mc, protected)
+		}
+
+		if !branchPass {
+			pass = false
+			text += branchText
+		}
 		ds[b] = d
 	}
 
@@ -421,6 +359,198 @@ func check(ctx context.Context, rep repositories, c *github.Client, owner,
 		NotifyText: text,
 		Details:    ds,
 	}, nil
+}
+
+func getProtectionDetails(p *github.Protection) details {
+	var d details
+
+	rev := p.GetRequiredPullRequestReviews()
+	if rev != nil {
+		d.PRReviews = true
+		d.DismissStale = rev.DismissStaleReviews
+		d.RequireCodeOwnerReviews = rev.RequireCodeOwnerReviews
+		d.NumReviews = rev.RequiredApprovingReviewCount
+	}
+
+	afp := p.GetAllowForcePushes()
+	d.BlockForce = true
+	if afp != nil {
+		d.BlockForce = !afp.Enabled
+	}
+
+	ea := p.GetEnforceAdmins()
+	d.EnforceOnAdmins = (ea != nil && ea.Enabled)
+
+	rsc := p.GetRequiredStatusChecks()
+	if rsc != nil {
+		d.RequireUpToDateBranch = rsc.Strict
+		for _, c := range rsc.GetChecks() {
+			d.RequireStatusChecks = append(d.RequireStatusChecks, StatusCheck{Context: c.Context, AppID: c.AppID})
+		}
+	}
+
+	return d
+}
+
+func getRulesetDetails(ctx context.Context, rep repositories, owner, repo, branch string) (details, bool, error) {
+	rules, rsp, err := rep.GetRulesForBranch(ctx, owner, repo, branch, nil)
+	if err != nil {
+		if rsp != nil && rsp.StatusCode == http.StatusNotFound {
+			return details{}, false, nil
+		}
+		if rsp != nil && rsp.StatusCode == http.StatusForbidden {
+			log.Warn().
+				Str("org", owner).
+				Str("repo", repo).
+				Str("area", polName).
+				Str("branch", branch).
+				Msg("Branch rulesets are not available on this repository.")
+			return details{}, false, nil
+		}
+		return details{}, false, err
+	}
+	if rules == nil {
+		return details{}, false, nil
+	}
+
+	var d details
+	protected := false
+
+	if len(rules.PullRequest) > 0 {
+		protected = true
+		d.PRReviews = true
+		for _, rule := range rules.PullRequest {
+			params := rule.Parameters
+			d.DismissStale = d.DismissStale || params.DismissStaleReviewsOnPush
+			d.RequireCodeOwnerReviews = d.RequireCodeOwnerReviews || params.RequireCodeOwnerReview
+			if params.RequiredApprovingReviewCount > d.NumReviews {
+				d.NumReviews = params.RequiredApprovingReviewCount
+			}
+		}
+	}
+
+	if len(rules.RequiredStatusChecks) > 0 {
+		protected = true
+		for _, rule := range rules.RequiredStatusChecks {
+			params := rule.Parameters
+			d.RequireUpToDateBranch = d.RequireUpToDateBranch || params.StrictRequiredStatusChecksPolicy
+			for _, check := range params.RequiredStatusChecks {
+				d.RequireStatusChecks = append(d.RequireStatusChecks, StatusCheck{
+					Context: check.Context,
+					AppID:   check.IntegrationID,
+				})
+			}
+		}
+	}
+
+	if len(rules.NonFastForward) > 0 {
+		protected = true
+		d.BlockForce = true
+	}
+	if len(rules.RequiredSignatures) > 0 {
+		protected = true
+		d.RequireSignedCommits = true
+	}
+
+	return d, protected, nil
+}
+
+func mergeDetails(a, b details) details {
+	a.PRReviews = a.PRReviews || b.PRReviews
+	if b.NumReviews > a.NumReviews {
+		a.NumReviews = b.NumReviews
+	}
+	a.DismissStale = a.DismissStale || b.DismissStale
+	a.BlockForce = a.BlockForce || b.BlockForce
+	a.EnforceOnAdmins = a.EnforceOnAdmins || b.EnforceOnAdmins
+	a.RequireUpToDateBranch = a.RequireUpToDateBranch || b.RequireUpToDateBranch
+	a.RequireStatusChecks = append(a.RequireStatusChecks, b.RequireStatusChecks...)
+	a.RequireSignedCommits = a.RequireSignedCommits || b.RequireSignedCommits
+	a.RequireCodeOwnerReviews = a.RequireCodeOwnerReviews || b.RequireCodeOwnerReviews
+	return a
+}
+
+func evaluateBranchDetails(branch string, d details, mc *mergedConfig, protected bool) (bool, string) {
+	if !protected {
+		return false, fmt.Sprintf("No protection found for branch %v\n", branch)
+	}
+
+	pass := true
+	text := ""
+	if d.PRReviews {
+		if mc.DismissStale && !d.DismissStale {
+			text += fmt.Sprintf("Dismiss stale reviews not configured for branch %v\n", branch)
+			pass = false
+		}
+		if d.NumReviews < mc.ApprovalCount {
+			pass = false
+			text += fmt.Sprintf("PR Approvals below threshold %v : %v for branch %v\n",
+				d.NumReviews, mc.ApprovalCount, branch)
+		}
+		if mc.RequireCodeOwnerReviews && !d.RequireCodeOwnerReviews {
+			text += fmt.Sprintf("Require Code Owner Reviews not configured for branch %v\n", branch)
+			pass = false
+		}
+	} else if mc.RequireApproval || mc.RequireCodeOwnerReviews {
+		pass = false
+		text += fmt.Sprintf("PR Approvals not configured for branch %v\n", branch)
+	}
+
+	if mc.BlockForce && !d.BlockForce {
+		text += fmt.Sprintf("Block force push not configured for branch %v\n", branch)
+		pass = false
+	}
+
+	if mc.EnforceOnAdmins && !d.EnforceOnAdmins {
+		text += fmt.Sprintf("Enforce status checks on admins not configured for branch %v\n",
+			branch)
+		pass = false
+	}
+
+	if len(mc.RequireStatusChecks) > 0 {
+		if len(d.RequireStatusChecks) == 0 {
+			text += fmt.Sprintf("Status checks required by policy, but none found for branch %v\n", branch)
+			pass = false
+		} else {
+			if mc.RequireUpToDateBranch && !d.RequireUpToDateBranch {
+				text += fmt.Sprintf("Require up to date branch not configured for branch %v\n",
+					branch)
+				pass = false
+			}
+			lt := makeSCLookupTable(toRequiredStatusChecks(d.RequireStatusChecks))
+			for _, c := range mc.RequireStatusChecks {
+				appIDTxt := "(any app)"
+				sch := statusCheckHash{context: c.Context}
+				if c.AppID != nil {
+					sch.appID = *c.AppID
+					appIDTxt = fmt.Sprintf("(AppID: %v)", *c.AppID)
+				}
+				if _, ok := lt[sch]; !ok {
+					text += fmt.Sprintf("Status check %s %s not found for branch %v\n",
+						c.Context, appIDTxt, branch)
+					pass = false
+				}
+			}
+		}
+	}
+
+	if mc.RequireSignedCommits && !d.RequireSignedCommits {
+		pass = false
+		text += fmt.Sprintf("Signed commits required, but not enabled for branch: %v\n", branch)
+	}
+
+	return pass, text
+}
+
+func toRequiredStatusChecks(checks []StatusCheck) []*github.RequiredStatusCheck {
+	rsc := make([]*github.RequiredStatusCheck, len(checks))
+	for i, check := range checks {
+		rsc[i] = &github.RequiredStatusCheck{
+			Context: check.Context,
+			AppID:   check.AppID,
+		}
+	}
+	return rsc
 }
 
 // Fix implementing policydef.Policy.Fix().

--- a/pkg/policies/branch/branch_test.go
+++ b/pkg/policies/branch/branch_test.go
@@ -37,6 +37,9 @@ var listBranches func(context.Context, string, string,
 var getBranchProtection func(context.Context, string, string, string) (
 	*github.Protection, *github.Response, error)
 
+var getRulesForBranch func(context.Context, string, string, string, *github.ListOptions) (
+	*github.BranchRules, *github.Response, error)
+
 var updateBranchProtection func(context.Context, string, string, string,
 	*github.ProtectionRequest) (*github.Protection, *github.Response, error)
 
@@ -64,6 +67,12 @@ func (m mockRepos) GetBranchProtection(ctx context.Context, o string, r string,
 	b string,
 ) (*github.Protection, *github.Response, error) {
 	return getBranchProtection(ctx, o, r, b)
+}
+
+func (m mockRepos) GetRulesForBranch(ctx context.Context, o string, r string,
+	b string, opts *github.ListOptions,
+) (*github.BranchRules, *github.Response, error) {
+	return getRulesForBranch(ctx, o, r, b, opts)
 }
 
 func (m mockRepos) UpdateBranchProtection(ctx context.Context, owner, repo,
@@ -316,6 +325,7 @@ func TestCheck(t *testing.T) {
 		Org           OrgConfig
 		Repo          RepoConfig
 		Prot          map[string]github.Protection
+		Rules         map[string]github.BranchRules
 		SigProtection map[string]github.SignaturesProtectedBranch
 		cofigEnabled  bool
 		Exp           policydef.Result
@@ -985,6 +995,243 @@ func TestCheck(t *testing.T) {
 			},
 		},
 		{
+			Name: "RulesetSatisfiesNoClassicProtection",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:          true,
+				RequireApproval:         true,
+				ApprovalCount:           2,
+				DismissStale:            true,
+				BlockForce:              true,
+				RequireCodeOwnerReviews: true,
+				RequireUpToDateBranch:   true,
+				RequireStatusChecks: []StatusCheck{
+					{"mycheck", nil},
+				},
+				RequireSignedCommits: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{},
+			Rules: map[string]github.BranchRules{
+				"main": {
+					PullRequest: []*github.PullRequestBranchRule{
+						{
+							Parameters: github.PullRequestRuleParameters{
+								DismissStaleReviewsOnPush:    true,
+								RequireCodeOwnerReview:       true,
+								RequiredApprovingReviewCount: 2,
+							},
+						},
+					},
+					RequiredStatusChecks: []*github.RequiredStatusChecksBranchRule{
+						{
+							Parameters: github.RequiredStatusChecksRuleParameters{
+								StrictRequiredStatusChecksPolicy: true,
+								RequiredStatusChecks: []*github.RuleStatusCheck{
+									{Context: "mycheck"},
+								},
+							},
+						},
+					},
+					NonFastForward:     []*github.BranchRuleMetadata{{}},
+					RequiredSignatures: []*github.BranchRuleMetadata{{}},
+				},
+			},
+			SigProtection: map[string]github.SignaturesProtectedBranch{
+				"main": {
+					Enabled: github.Ptr(false),
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       true,
+				NotifyText: "",
+				Details: map[string]details{
+					"main": {
+						PRReviews:               true,
+						NumReviews:              2,
+						DismissStale:            true,
+						BlockForce:              true,
+						RequireUpToDateBranch:   true,
+						RequireStatusChecks:     []StatusCheck{{"mycheck", nil}},
+						RequireSignedCommits:    true,
+						RequireCodeOwnerReviews: true,
+					},
+				},
+			},
+		},
+		{
+			Name: "RulesetCompletesIncompleteClassicProtection",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   2,
+				DismissStale:    true,
+				BlockForce:      true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{
+				"main": {
+					RequiredPullRequestReviews: &github.PullRequestReviewsEnforcement{
+						DismissStaleReviews:          true,
+						RequiredApprovingReviewCount: 1,
+					},
+					AllowForcePushes: &github.AllowForcePushes{
+						Enabled: true,
+					},
+				},
+			},
+			Rules: map[string]github.BranchRules{
+				"main": {
+					PullRequest: []*github.PullRequestBranchRule{
+						{
+							Parameters: github.PullRequestRuleParameters{
+								DismissStaleReviewsOnPush:    true,
+								RequiredApprovingReviewCount: 2,
+							},
+						},
+					},
+					NonFastForward: []*github.BranchRuleMetadata{{}},
+				},
+			},
+			SigProtection: map[string]github.SignaturesProtectedBranch{
+				"main": {
+					Enabled: github.Ptr(false),
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       true,
+				NotifyText: "",
+				Details: map[string]details{
+					"main": {
+						PRReviews:    true,
+						NumReviews:   2,
+						DismissStale: true,
+						BlockForce:   true,
+					},
+				},
+			},
+		},
+		{
+			Name: "RulesetDoesNotSatisfyMissingStatusCheck",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:        true,
+				RequireApproval:       true,
+				ApprovalCount:         1,
+				DismissStale:          true,
+				BlockForce:            true,
+				RequireUpToDateBranch: true,
+				RequireStatusChecks: []StatusCheck{
+					{"mycheck", nil}, {"theothercheck", nil},
+				},
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{},
+			Rules: map[string]github.BranchRules{
+				"main": {
+					PullRequest: []*github.PullRequestBranchRule{
+						{
+							Parameters: github.PullRequestRuleParameters{
+								DismissStaleReviewsOnPush:    true,
+								RequiredApprovingReviewCount: 1,
+							},
+						},
+					},
+					RequiredStatusChecks: []*github.RequiredStatusChecksBranchRule{
+						{
+							Parameters: github.RequiredStatusChecksRuleParameters{
+								StrictRequiredStatusChecksPolicy: true,
+								RequiredStatusChecks: []*github.RuleStatusCheck{
+									{Context: "mycheck"},
+								},
+							},
+						},
+					},
+					NonFastForward: []*github.BranchRuleMetadata{{}},
+				},
+			},
+			SigProtection: map[string]github.SignaturesProtectedBranch{
+				"main": {
+					Enabled: github.Ptr(false),
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Status check theothercheck (any app) not found for branch main\n",
+				Details: map[string]details{
+					"main": {
+						PRReviews:             true,
+						NumReviews:            1,
+						DismissStale:          true,
+						BlockForce:            true,
+						RequireUpToDateBranch: true,
+						RequireStatusChecks:   []StatusCheck{{"mycheck", nil}},
+					},
+				},
+			},
+		},
+		{
+			Name: "RulesetDoesNotSatisfyEnforceOnAdmins",
+			Org: OrgConfig{
+				OptConfig: config.OrgOptConfig{
+					OptOutStrategy: true,
+				},
+				EnforceDefault:  true,
+				RequireApproval: true,
+				ApprovalCount:   1,
+				DismissStale:    true,
+				BlockForce:      true,
+				EnforceOnAdmins: true,
+			},
+			Repo: RepoConfig{},
+			Prot: map[string]github.Protection{},
+			Rules: map[string]github.BranchRules{
+				"main": {
+					PullRequest: []*github.PullRequestBranchRule{
+						{
+							Parameters: github.PullRequestRuleParameters{
+								DismissStaleReviewsOnPush:    true,
+								RequiredApprovingReviewCount: 1,
+							},
+						},
+					},
+					NonFastForward: []*github.BranchRuleMetadata{{}},
+				},
+			},
+			SigProtection: map[string]github.SignaturesProtectedBranch{
+				"main": {
+					Enabled: github.Ptr(false),
+				},
+			},
+			cofigEnabled: true,
+			Exp: policydef.Result{
+				Enabled:    true,
+				Pass:       false,
+				NotifyText: "Enforce status checks on admins not configured for branch main\n",
+				Details: map[string]details{
+					"main": {
+						PRReviews:    true,
+						NumReviews:   1,
+						DismissStale: true,
+						BlockForce:   true,
+					},
+				},
+			},
+		},
+		{
 			Name: "SignedCommitsRequiredNotEnabled",
 			Org: OrgConfig{
 				OptConfig: config.OrgOptConfig{
@@ -1313,6 +1560,19 @@ func TestCheck(t *testing.T) {
 						},
 					}, errors.New("404")
 				}
+			}
+			getRulesForBranch = func(ctx context.Context, o string, r string,
+				b string, opts *github.ListOptions,
+			) (*github.BranchRules, *github.Response, error) {
+				rules, ok := test.Rules[b]
+				if ok {
+					return &rules, nil, nil
+				}
+				return nil, &github.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusNotFound,
+					},
+				}, errors.New("404")
 			}
 			getSignaturesProtectedBranch = func(ctx context.Context, o string, r string, b string) (
 				*github.SignaturesProtectedBranch, *github.Response, error,

--- a/whats-new.md
+++ b/whats-new.md
@@ -5,6 +5,8 @@ Major features and changes added to Allstar.
 ## Added since last release
 
 - Dangerous Workflow policy will now be run for all branches. [Link](https://github.com/ossf/allstar/issues/569)
+- Branch Protection policy can now recognize equivalent active repository
+  rulesets when checking branch requirements. [Link](https://github.com/ossf/allstar/issues/475)
 
 ## Release v3.0
 


### PR DESCRIPTION
## Summary

Adds Check-only Repository Rulesets support to the existing Branch Protection policy.

This keeps the existing classic branch protection behavior, but when a branch is missing or incomplete under classic branch protection, Allstar also checks the active rules returned by `Repositories.GetRulesForBranch`.

The policy now recognizes direct ruleset equivalents for:
- pull request reviews
- required approving review count
- stale review dismissal
- code owner reviews
- required status checks
- strict/up-to-date status checks
- signed commits
- non-fast-forward protection

This intentionally does not add Fix/CRUD support for rulesets. The existing `fix` action still updates classic branch protection only.

Fixes #475

## Testing

- `PATH=/tmp/go/bin:$PATH go test ./pkg/policies/branch`
- `PATH=/tmp/go/bin:$PATH go test ./pkg/policies/...`
- `PATH=/tmp/go/bin:$PATH go test ./...`
- `PATH=/tmp/go/bin:$PATH go vet ./...`
- `PATH=/tmp/go/bin:$PATH go build ./...`
- `PATH=/tmp/go/bin:$PATH /tmp/go-tools/golangci-lint run --timeout 5m --verbose`
- `git diff --check`

## Live validation

Validated against a disposable public repository:
https://github.com/bmendonca3/allstar-rulesets-validation-20260528154925

Before creating a ruleset:
- active branch rules: `pull_request=0 status_checks=0 non_fast_forward=0 required_signatures=0`
- Allstar Check result: `enabled=true pass=false`
- notify text: `No protection found for branch main`

After creating an active ruleset for `main` with pull request review and non-fast-forward rules:
- active branch rules: `pull_request=1 status_checks=0 non_fast_forward=1 required_signatures=0`
- Allstar Check result: `enabled=true pass=true`
- notify text: empty

## Scope note

Rulesets are not used to satisfy `enforceOnAdmins`, because rulesets model bypass behavior differently than classic branch protection.
