### PR TITLE
enforce: warn when app has zero installations

### DIFF
--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -89,6 +89,15 @@ func EnforceAll(ctx context.Context, ghc ghclients.GhClientsInterface, specificP
 		Int("count", len(insts)).
 		Msg("Enforcing policies on installations.")
 
+	if len(insts) == 0 {
+		log.Warn().
+			Str("area", "bot").
+			Msg("App authentication succeeded but no installations were found. " +
+				"Allstar will not enforce any policies. The app is likely not " +
+				"installed on any organization. Install it on the relevant org(s) " +
+				"via the app's Settings page -> Install App tab.")
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(operator.NumWorkers)
 	var mu sync.Mutex

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -15,6 +15,7 @@
 package enforce
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v84/github"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
@@ -560,6 +563,52 @@ func TestEnforceAll(t *testing.T) {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestEnforceAllNoInstallations(t *testing.T) {
+	// Regression test for https://github.com/ossf/allstar/issues/294: when the
+	// app is authenticated but installed in zero orgs, EnforceAll used to exit
+	// silently. It should now emit a warning pointing the operator at the
+	// missing installation step.
+	getAppInstallations = func(ctx context.Context, ac *github.Client) ([]*github.Installation, error) {
+		return []*github.Installation{}, nil
+	}
+	gaicalled := false
+	getAppInstallationRepos = func(ctx context.Context, ic *github.Client) ([]*github.Repository, *github.Response, error) {
+		gaicalled = true
+		return nil, nil, nil
+	}
+
+	// Capture the zerolog global logger output and make sure the warn level is
+	// not filtered out, restoring both when the test finishes.
+	var buf bytes.Buffer
+	savedLogger := log.Logger
+	savedLevel := zerolog.GlobalLevel()
+	log.Logger = zerolog.New(&buf)
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	defer func() {
+		log.Logger = savedLogger
+		zerolog.SetGlobalLevel(savedLevel)
+	}()
+
+	enforceAllResults, err := EnforceAll(context.Background(), &MockGhClients{}, "", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if gaicalled {
+		t.Errorf("Expected getAppInstallationRepos() to not be called with no installations, but was")
+	}
+	if len(enforceAllResults) != 0 {
+		t.Errorf("Expected empty results with no installations, got: %+v", enforceAllResults)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "\"level\":\"warn\"") {
+		t.Errorf("Expected a warn-level log entry, got: %s", out)
+	}
+	if !strings.Contains(out, "no installations were found") {
+		t.Errorf("Expected log to mention that no installations were found, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
Fixes #294

### Problem

When the Allstar GitHub App is authenticated but installed in zero organizations, `EnforceAll` (in `pkg/enforce/enforce.go`) lists installations, logs `count:0` and `EnforceAll complete` at INFO level, and then iterates an empty slice without enforcing anything. There is no signal that the app simply was not installed anywhere, which is the most common cause. The issue reporter spent time debugging this because invalid `PRIVATE_KEY` / `APP_ID` both produce clear errors, but the much more likely "authenticated but not installed" case is silent.

### Change

After the existing `Enforcing policies on installations.` log, when `len(insts) == 0`, emit a `log.Warn` stating that authentication succeeded but no installations were found, that no policies will be enforced, and pointing the operator at the install step (app Settings page -> Install App tab). The logging matches the surrounding zerolog style (`Str("area", "bot")`).

### Test

Added `TestEnforceAllNoInstallations`, which mocks `getAppInstallations` to return an empty slice, captures the zerolog global logger into a buffer, and asserts a warn-level entry mentioning "no installations were found" is produced. It also confirms `getAppInstallationRepos` is not called and the results map is empty. I verified the test is a real regression test: it fails against the unpatched `enforce.go` and passes with the fix.

```
$ go test ./pkg/enforce/...
ok  	github.com/ossf/allstar/pkg/enforce	1.296s
```

`gofmt -l` and `go vet ./pkg/enforce/...` are both clean on the changed files.

### Note on docs

The original issue also suggested adding a step to `operator.md` documenting that the app must be installed into an org. I kept this PR scoped to the code fix and its test so the behavior change is easy to review on its own. Happy to follow up with the docs update (or fold it in here) if maintainers prefer.

This commit is DCO signed off (`Signed-off-by`).
