### PR TITLE
Retry transient GitHub gateway errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v84 v84.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ossf/scorecard/v5 v5.5.0
 	github.com/rhysd/actionlint v1.7.12
 	github.com/rs/zerolog v1.35.1
@@ -139,7 +140,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.19.0 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hmarr/codeowners v1.2.1 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect

--- a/pkg/ghclients/ghclients.go
+++ b/pkg/ghclients/ghclients.go
@@ -121,7 +121,7 @@ func (g *GHClients) Get(i int64) (*github.Client, error) {
 		tr = ghiTransport
 	}
 
-	c := github.NewClient(&http.Client{Transport: tr})
+	c := github.NewClient(&http.Client{Transport: newRetryRoundTripper(tr)})
 	if operator.GitHubEnterpriseUrl != "" {
 		newC, err := c.WithEnterpriseURLs(operator.GitHubEnterpriseUrl, operator.GitHubEnterpriseUrl)
 		if err != nil {

--- a/pkg/ghclients/retry.go
+++ b/pkg/ghclients/retry.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Allstar Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghclients
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// newRetryRoundTripper retries the transient gateway errors that GitHub uses
+// when an idempotent API request times out. The retryable client applies
+// exponential backoff and stops when the request context is canceled.
+func newRetryRoundTripper(base http.RoundTripper) http.RoundTripper {
+	client := retryablehttp.NewClient()
+	client.HTTPClient.Transport = base
+	client.Logger = nil
+	client.CheckRetry = retryGatewayErrors
+	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	return &retryablehttp.RoundTripper{Client: client}
+}
+
+func retryGatewayErrors(ctx context.Context, resp *http.Response, _ error) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if resp == nil {
+		return false, nil
+	}
+	if resp.Request == nil || !isIdempotentMethod(resp.Request.Method) {
+		return false, nil
+	}
+
+	return resp.StatusCode == http.StatusBadGateway ||
+		resp.StatusCode == http.StatusGatewayTimeout, nil
+}
+
+func isIdempotentMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/ghclients/retry_test.go
+++ b/pkg/ghclients/retry_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Allstar Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghclients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+func TestRetryRoundTripperRetriesGatewayErrors(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		switch requests.Add(1) {
+		case 1:
+			http.Error(w, "temporary bad gateway", http.StatusBadGateway)
+		case 2:
+			http.Error(w, "temporary gateway timeout", http.StatusGatewayTimeout)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"name":"demo"}`)); err != nil {
+				t.Errorf("response write failed: %v", err)
+			}
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server, 2)
+	repository, _, err := client.Repositories.Get(context.Background(), "demo", "demo")
+	if err != nil {
+		t.Fatalf("Repositories.Get returned an unexpected error: %v", err)
+	}
+	if got, want := repository.GetName(), "demo"; got != want {
+		t.Errorf("repository name = %q, want %q", got, want)
+	}
+	if got, want := requests.Load(), int32(3); got != want {
+		t.Errorf("request count = %d, want %d", got, want)
+	}
+}
+
+func TestRetryRoundTripperDoesNotRetryOtherServerErrors(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server, 2)
+	_, response, err := client.Repositories.Get(context.Background(), "demo", "demo")
+	if err == nil {
+		t.Fatal("Repositories.Get returned nil error for HTTP 500")
+	}
+	if response == nil || response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("response = %#v, want HTTP 500", response)
+	}
+	if got, want := requests.Load(), int32(1); got != want {
+		t.Errorf("request count = %d, want %d", got, want)
+	}
+}
+
+func TestRetryRoundTripperDoesNotRetryNonIdempotentRequests(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "temporary bad gateway", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server, 2)
+	_, response, err := client.Issues.Create(
+		context.Background(), "demo", "demo", &github.IssueRequest{Title: github.Ptr("demo")})
+	if err == nil {
+		t.Fatal("Issues.Create returned nil error for HTTP 502")
+	}
+	if response == nil || response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("response = %#v, want HTTP 502", response)
+	}
+	if got, want := requests.Load(), int32(1); got != want {
+		t.Errorf("request count = %d, want %d", got, want)
+	}
+}
+
+func TestRetryRoundTripperReturnsLastGatewayResponse(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "gateway timeout", http.StatusGatewayTimeout)
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server, 2)
+	_, response, err := client.Repositories.Get(context.Background(), "demo", "demo")
+	if err == nil {
+		t.Fatal("Repositories.Get returned nil error for persistent HTTP 504")
+	}
+	if response == nil || response.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("response = %#v, want HTTP 504", response)
+	}
+	if got, want := requests.Load(), int32(3); got != want {
+		t.Errorf("request count = %d, want %d", got, want)
+	}
+}
+
+func newTestGitHubClient(t *testing.T, server *httptest.Server, retryMax int) *github.Client {
+	t.Helper()
+
+	transport := newRetryRoundTripper(server.Client().Transport)
+	retryTransport, ok := transport.(*retryablehttp.RoundTripper)
+	if !ok {
+		t.Fatalf("transport has type %T, want *retryablehttp.RoundTripper", transport)
+	}
+	retryTransport.Client.RetryWaitMin = 0
+	retryTransport.Client.RetryWaitMax = 0
+	retryTransport.Client.RetryMax = retryMax
+
+	client := github.NewClient(&http.Client{Transport: transport})
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("url.Parse returned an unexpected error: %v", err)
+	}
+	client.BaseURL = baseURL
+	return client
+}


### PR DESCRIPTION
## Summary

- retry GitHub API responses with status 502 or 504 using exponential backoff
- limit automatic retries to idempotent HTTP methods so issue/comment creation and other non-idempotent mutations are not duplicated
- preserve the final gateway response when the retry budget is exhausted

The implementation reuses `go-retryablehttp`, which was already present in the module graph, and applies the retry transport to both app-level and installation-level GitHub clients.

Fixes #57.

## Validation

- `go test ./pkg/ghclients -count=1`
- real `httptest` + `go-github` paths: 502 -> 504 -> 200, non-gateway 500, non-idempotent POST, and persistent 504
- `go test` for every package except `pkg/scorecard`
- `go build ./...`
- `go vet ./...`
- `go mod verify`
- `golangci-lint run --timeout 5m --new-from-rev=HEAD`

On Windows, the unmodified `pkg/scorecard` `TestLocal` fails after its temporary `go-git/go-git` clone reports unstaged changes while switching branches. All other packages pass; this change does not touch that package.

## AI assistance

OpenAI Codex assisted with issue screening, implementation, and tests. I reviewed the patch and ran the validation listed above.
