### PR TITLE
Warn when no GitHub App installations are found

### DIFF
--- a/operator.md
+++ b/operator.md
@@ -26,6 +26,16 @@ to create a new app.
 > **Note:** As Allstar is developed, it may evolve the permissions needed or start
 > listening for webhooks, please follow along development in this repo.
 
+## Install the GitHub App
+
+After creating the GitHub App, install it into each organization where you
+want Allstar to enforce policies. From the GitHub App settings page, select
+**Install App**, choose the organization, and complete the installation.
+
+Creating the app and configuring its credentials is not sufficient on its own.
+Allstar can authenticate successfully without any installations, but it will
+not have repositories on which to enforce policies until the app is installed.
+
 ## Get ID and key.
 
 See [the

--- a/pkg/enforce/enforce.go
+++ b/pkg/enforce/enforce.go
@@ -88,6 +88,11 @@ func EnforceAll(ctx context.Context, ghc ghclients.GhClientsInterface, specificP
 		Str("area", "bot").
 		Int("count", len(insts)).
 		Msg("Enforcing policies on installations.")
+	if len(insts) == 0 {
+		log.Warn().
+			Str("area", "bot").
+			Msg("App authentication succeeded but no installations were found. Install the GitHub App into an organization before running Allstar.")
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(operator.NumWorkers)

--- a/pkg/enforce/enforce_test.go
+++ b/pkg/enforce/enforce_test.go
@@ -15,6 +15,7 @@
 package enforce
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v84/github"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 
 	"github.com/ossf/allstar/pkg/config/operator"
 	"github.com/ossf/allstar/pkg/policydef"
@@ -363,6 +366,36 @@ func TestDoNothingOnOptOut(t *testing.T) {
 				t.Errorf("Unexpected results. (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestEnforceAllNoInstallations(t *testing.T) {
+	var buf bytes.Buffer
+
+	previousLogger := zlog.Logger
+	zlog.Logger = zerolog.New(&buf)
+	defer func() {
+		zlog.Logger = previousLogger
+	}()
+
+	previousGetAppInstallations := getAppInstallations
+	getAppInstallations = func(ctx context.Context, ac *github.Client) ([]*github.Installation, error) {
+		return []*github.Installation{}, nil
+	}
+	defer func() {
+		getAppInstallations = previousGetAppInstallations
+	}()
+
+	results, err := EnforceAll(context.Background(), &MockGhClients{}, "", "")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Expected no results, got %v", results)
+	}
+
+	if !strings.Contains(buf.String(), "no installations were found") {
+		t.Errorf("Expected a diagnostic when no GitHub App installations were found, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
Closes #294.

This adds an explicit warning when Allstar authenticates successfully but finds no GitHub App installations, so operators are not left with a silent no-op enforcement cycle.

It also updates `operator.md` with the missing step to install the GitHub App into the target organization(s), and adds a regression test for the zero-installations case.

Validation:
- `go test -v ./pkg/enforce -run TestEnforceAllNoInstallations`
- `go test -v ./pkg/enforce -run TestEnforceAll`
- `git diff --check`
- `golangci-lint run --new-from-rev=upstream/main --whole-files`

A full local `go test -v ./...` run on Windows reached an unrelated `pkg/scorecard/TestLocal` failure while switching branches in its temporary `go-git/go-git` worktree (`worktree contains unstaged changes`). The PR CI runs the full test suite on Ubuntu.