### PR TITLE
.github: Generate release notes and draft releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,9 +54,22 @@ jobs:
             cosign sign --yes -a git_sha="$GITHUB_SHA" "$ref"
           done < allstar-gha.ref
 
+      # Creates a draft so a maintainer can add highlights and correct the
+      # generated changelog before it is published. Publishing is manual.
       - run: |
-          gh release create ${{ github.ref_name }} --notes "Images:
-          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }} # Minimal image based on scratch
-          * ghcr.io/${{ github.repository_owner }}/allstar:${{ github.ref_name }}-gha # Image for use as a GitHub Action"
+          cat > release-notes.md <<EOF
+          Images:
+          * ghcr.io/$OWNER/allstar:$TAG # Minimal image based on scratch
+          * ghcr.io/$OWNER/allstar:$TAG-gha # Image for use as a GitHub Action
+          EOF
+
+          gh release create "$TAG" \
+            --draft \
+            --verify-tag \
+            --title "$TAG" \
+            --generate-notes \
+            --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          TAG: ${{ github.ref_name }}


### PR DESCRIPTION
The release step published immediately with a fixed `--notes` string listing only the two container images. Every release that carried a real changelog got one from a maintainer editing the release after the fact and clicking Generate release notes — an invisible step that was missed for v2.0, whose release has no title at all, and for v4.0.

Generate the notes in the workflow and create the release as a draft instead. The image list is passed via `--notes-file`, which GitHub prepends to the generated changelog, so the maintainer opens a draft that already has both and edits it into shape before publishing.

Pass `--title` explicitly rather than relying on `--generate-notes` to derive one, and `--verify-tag` so a mistyped ref fails instead of silently creating a tag.

Read the tag and owner from the step environment rather than expanding them inline. This drops the workflow's high-severity zizmor template-injection findings from 6 to 3; the remaining 3 predate this change and are left alone.