### PR TITLE
Make issue ping duration organization configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,8 +482,14 @@ organization.
 
 ### Configuration Definitions
 
+- [Organization-level Allstar configuration](https://pkg.go.dev/github.com/ossf/allstar/pkg/config#OrgConfig)
 - [Organization level enable configuration](https://pkg.go.dev/github.com/ossf/allstar/pkg/config#OrgOptConfig)
 - [Repository Override enable configuration]( https://pkg.go.dev/github.com/ossf/allstar/pkg/config#RepoOptConfig)
+
+Set `noticePingDurationHours` in the organization-level `allstar.yaml` to
+control how long Allstar waits before adding a reminder comment to an unresolved
+issue. For example, `noticePingDurationHours: 168` waits one week. If omitted or
+less than one, the app operator's configured interval is used.
 
 ### Secondary Org-Level configuration location
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,11 @@ type OrgConfig struct {
 	// a specific configuration
 	IssueDetails string `json:"issueDetails"`
 
+	// NoticePingDurationHours is the number of hours Allstar waits before adding a
+	// reminder comment to an unresolved issue. Values less than one use the
+	// operator-configured default.
+	NoticePingDurationHours int64 `json:"noticePingDurationHours"`
+
 	// Schedule specifies whether to perform certain actions on specific days.
 	Schedule *ScheduleConfig `json:"schedule"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -167,6 +167,16 @@ issueDetails: test Issue Detail
 			},
 			Got: &OrgConfig{},
 		},
+		{
+			Name: "NoticePingDurationHours",
+			Input: `
+noticePingDurationHours: 168
+`,
+			Expect: &OrgConfig{
+				NoticePingDurationHours: 168,
+			},
+			Got: &OrgConfig{},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/issue/issue.go
+++ b/pkg/issue/issue.go
@@ -220,7 +220,11 @@ func ensure(ctx context.Context, c *github.Client, issues issues, owner, repo, p
 		_, _, err := issues.CreateComment(ctx, owner, issueRepo, issue.GetNumber(), comment)
 		return err
 	}
-	if issue.GetUpdatedAt().Before(time.Now().Add(-1 * operator.NoticePingDuration)) {
+	noticePingDuration := operator.NoticePingDuration
+	if oc.NoticePingDurationHours > 0 {
+		noticePingDuration = time.Duration(oc.NoticePingDurationHours) * time.Hour
+	}
+	if issue.GetUpdatedAt().Before(time.Now().Add(-1 * noticePingDuration)) {
 		body := fmt.Sprintf("Updating issue after ping interval. See its status below.\n\n---\n\n%s", text)
 		comment := &github.IssueComment{
 			Body: &body,

--- a/pkg/issue/issue_test.go
+++ b/pkg/issue/issue_test.go
@@ -336,6 +336,48 @@ func TestEnsure(t *testing.T) {
 			t.Error("Expected comment to be left")
 		}
 	})
+	t.Run("OpenIssueWithCustomPingDuration", func(t *testing.T) {
+		oldConfigGetAppConfigs := configGetAppConfigs
+		oldScheduleShouldPerform := scheduleShouldPerform
+		defer func() {
+			configGetAppConfigs = oldConfigGetAppConfigs
+			scheduleShouldPerform = oldScheduleShouldPerform
+		}()
+		configGetAppConfigs = func(context.Context, *github.Client, string, string) (*config.OrgConfig, *config.RepoConfig, *config.RepoConfig) {
+			return &config.OrgConfig{NoticePingDurationHours: 1}, &config.RepoConfig{}, &config.RepoConfig{}
+		}
+		setShouldPerform(true)
+		stale := github.Timestamp{Time: time.Now().Add(-2 * time.Hour)}
+		listByRepo = func(ctx context.Context, owner string, repo string,
+			opts *github.IssueListByRepoOptions,
+		) ([]*github.Issue, *github.Response, error) {
+			return []*github.Issue{
+				{
+					Title:     &issueTitle,
+					State:     &open,
+					UpdatedAt: &stale,
+				},
+			}, &github.Response{NextPage: 0}, nil
+		}
+		commentCalled := false
+		createComment = func(ctx context.Context, owner string, repo string,
+			number int, comment *github.IssueComment,
+		) (*github.IssueComment, *github.Response, error) {
+			if !strings.HasPrefix(comment.GetBody(), "Updating issue") {
+				t.Errorf("Unexpected comment: %v", comment.GetBody())
+			}
+			commentCalled = true
+			return nil, nil, nil
+		}
+		create = nil
+		edit = nil
+		if err := ensure(context.Background(), nil, mockIssues{}, "", "", "thispolicy", "Status text"); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !commentCalled {
+			t.Error("Expected issue to be pinged after the custom interval")
+		}
+	})
 	t.Run("NoIssueScheduleBlocksCreate", func(t *testing.T) {
 		setShouldPerform(false)
 		listByRepo = func(ctx context.Context, owner string, repo string,


### PR DESCRIPTION
Closes #117.

## Summary
- add `noticePingDurationHours` to organization-level `allstar.yaml` configuration
- use the organization value for unresolved-issue reminder comments, falling back to the operator default when omitted or less than one
- document the option and cover config parsing and custom interval behavior

## Verification
- `go test ./pkg/config ./pkg/issue`
- `go test ./...`
- `git diff --check`